### PR TITLE
Bump actions to Node 24 runtimes

### DIFF
--- a/.github/actions/deploy-to-gcs/action.yml
+++ b/.github/actions/deploy-to-gcs/action.yml
@@ -24,12 +24,12 @@ runs:
   using: 'composite'
   steps:
     - name: 🔐 Set up GCP credentials
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         credentials_json: ${{ inputs.credentials_json }}
 
     - name: Upload SDK to GCS bucket
-      uses: google-github-actions/upload-cloud-storage@v2
+      uses: google-github-actions/upload-cloud-storage@v3
       with:
         path: ${{ inputs.sdk_path }}
         destination: ${{ inputs.bucket_name }}/${{ inputs.destination_path }}
@@ -37,7 +37,7 @@ runs:
         process_gcloudignore: 'false'
 
     - name: Upload APP to GCS bucket
-      uses: google-github-actions/upload-cloud-storage@v2
+      uses: google-github-actions/upload-cloud-storage@v3
       with:
         path: ${{ inputs.app_path }}
         destination: ${{ inputs.bucket_name }}/${{ inputs.destination_path }}

--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -11,7 +11,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node_version }}
 

--- a/.github/workflows/on_dev_manual.yml
+++ b/.github/workflows/on_dev_manual.yml
@@ -35,7 +35,7 @@ jobs:
           echo "✅ Ref '$REF_NAME' is safe to deploy to sdk/$REF_NAME/"
 
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup project environment
         uses: ./.github/actions/setup-project

--- a/.github/workflows/on_main_push.yml
+++ b/.github/workflows/on_main_push.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup project environment
         uses: ./.github/actions/setup-project

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6, `actions/setup-node` v4 → v6, `google-github-actions/auth` v2 → v3, `google-github-actions/upload-cloud-storage` v2 → v3
- GitHub forces actions onto Node 24 on **June 16, 2026** and removes Node 20 from runners on **September 16, 2026**; the previous majors run on Node 20

No behavior changes for our usage:
- checkout v6 still persists credentials (used by the version-bump push to main in the release workflow), they are just stored in a separate file now
- setup-node v5+ auto-caching only activates with a `packageManager` field in package.json, which we don't have
- auth/upload v3 keep the `credentials_json` flow, only the runtime changed

## Test plan
- ✅ Manual dispatch run from this branch: full pipeline (checkout → npm ci → 3 builds → deploys to dev/preprod/prod buckets) passed with the bumped actions
- The release-specific steps (`gh release upload`, version-bump push to main) are covered by changelog review; first real release will confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)