### PR TITLE
Grouped predefined models for shoes mode

### DIFF
--- a/app/src/components/index.ts
+++ b/app/src/components/index.ts
@@ -50,6 +50,7 @@ export { UploadPreview } from './picker/UploadPreview'
 export { UploadResult } from './picker/UploadResult'
 export { UploadsHistorySheet } from './picker/UploadsHistorySheet'
 export { ModelsList } from './picker/ModelsList'
+export { ModelsGroups } from './picker/ModelsGroups'
 
 // Gallery
 export { ImageGallery } from './gallery/ImageGallery'

--- a/app/src/components/picker/ModelsGroups/ModelsGroups.module.scss
+++ b/app/src/components/picker/ModelsGroups/ModelsGroups.module.scss
@@ -1,0 +1,92 @@
+// Vertical scroller of view groups
+.groups {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 0 8px 8px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  scrollbar-width: none;
+}
+
+.groupLabel {
+  margin: 0 0 8px;
+  color: var(--aiuta-color-secondary);
+}
+
+.rowWrap {
+  position: relative;
+}
+
+// Horizontal scroller of model cards
+.row {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x proximity;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  scrollbar-width: none;
+}
+
+// Figma model card: 153×240, 16px radius (from the M image shape). Relative so
+// the absolutely-positioned RemoteImage fills the card instead of escaping to
+// the nearest positioned ancestor (the row wrap). Desktop uses one size for all
+// groups; mobile makes the full-height cards larger and the other views smaller.
+.card {
+  position: relative;
+  flex-shrink: 0;
+  width: 153px;
+  height: 240px;
+  cursor: pointer;
+  scroll-snap-align: start;
+}
+
+@media (max-width: 992px) {
+  .card {
+    width: 120px;
+    height: 188px;
+  }
+
+  .card_large {
+    width: 165px;
+    height: 258px;
+  }
+}
+
+// Round scroll arrows (desktop only), overhanging the row edges
+.arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: var(--aiuta-color-background);
+  color: var(--aiuta-color-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  cursor: pointer;
+}
+
+.arrow_left {
+  left: -4px;
+}
+
+.arrow_right {
+  right: -4px;
+}

--- a/app/src/components/picker/ModelsGroups/ModelsGroups.tsx
+++ b/app/src/components/picker/ModelsGroups/ModelsGroups.tsx
@@ -1,0 +1,115 @@
+import React, { useRef } from 'react'
+import { useAppSelector } from '@/store/store'
+import { isMobileSelector } from '@/store/slices/appSlice'
+import { RemoteImage } from '@/components'
+import { combineClassNames } from '@/utils'
+import type { TryOnModel } from '@/utils/api'
+import styles from './ModelsGroups.module.scss'
+
+export interface ModelGroup {
+  view: string
+  label: string
+  models: TryOnModel[]
+}
+
+interface ModelsGroupsProps {
+  groups: ModelGroup[]
+  onModelSelect: (model: TryOnModel) => void
+}
+
+// ~ one card (153px) + gap (8px)
+const SCROLL_STEP = 161
+
+const Chevron = ({ dir }: { dir: 'left' | 'right' }) => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path
+      d={dir === 'left' ? 'M10 3 5 8l5 5' : 'M6 3l5 5-5 5'}
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const GroupRow = ({
+  group,
+  showArrows,
+  onModelSelect,
+}: {
+  group: ModelGroup
+  showArrows: boolean
+  onModelSelect: (model: TryOnModel) => void
+}) => {
+  const rowRef = useRef<HTMLDivElement>(null)
+
+  const scrollBy = (delta: number) => rowRef.current?.scrollBy({ left: delta, behavior: 'smooth' })
+
+  return (
+    <section className={styles.group}>
+      <p className={combineClassNames('aiuta-label-subtle', styles.groupLabel)}>{group.label}</p>
+
+      <div className={styles.rowWrap}>
+        {showArrows && (
+          <button
+            type="button"
+            aria-label="Scroll left"
+            className={combineClassNames(styles.arrow, styles.arrow_left)}
+            onClick={() => scrollBy(-SCROLL_STEP)}
+          >
+            <Chevron dir="left" />
+          </button>
+        )}
+
+        <div ref={rowRef} className={styles.row} data-scrollable>
+          {group.models.map((model) => (
+            <div
+              key={model.id}
+              className={combineClassNames(
+                styles.card,
+                // Mobile only: full-height cards are larger than the other views
+                group.view === 'full-height' && styles.card_large,
+              )}
+              onClick={() => onModelSelect(model)}
+            >
+              <RemoteImage src={model.url} alt="Model" shape="M" fit="smart" />
+            </div>
+          ))}
+        </div>
+
+        {showArrows && (
+          <button
+            type="button"
+            aria-label="Scroll right"
+            className={combineClassNames(styles.arrow, styles.arrow_right)}
+            onClick={() => scrollBy(SCROLL_STEP)}
+          >
+            <Chevron dir="right" />
+          </button>
+        )}
+      </div>
+    </section>
+  )
+}
+
+/**
+ * Shoes model picker body: a vertically-scrolling list of view groups, each a
+ * horizontally-scrolling row of model cards (Figma). Desktop adds per-row
+ * arrow buttons; mobile is touch-scroll only.
+ */
+export const ModelsGroups = ({ groups, onModelSelect }: ModelsGroupsProps) => {
+  const isMobile = useAppSelector(isMobileSelector)
+
+  return (
+    <div className={styles.groups} data-scrollable>
+      {groups.map((group) => (
+        <GroupRow
+          key={group.view}
+          group={group}
+          showArrows={!isMobile}
+          onModelSelect={onModelSelect}
+        />
+      ))}
+    </div>
+  )
+}

--- a/app/src/components/picker/ModelsGroups/index.ts
+++ b/app/src/components/picker/ModelsGroups/index.ts
@@ -1,0 +1,2 @@
+export { ModelsGroups } from './ModelsGroups'
+export type { ModelGroup } from './ModelsGroups'

--- a/app/src/hooks/models/usePredefinedModelsSelection.ts
+++ b/app/src/hooks/models/usePredefinedModelsSelection.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useAppDispatch } from '@/store/store'
+import { useAppDispatch, useAppSelector } from '@/store/store'
 import { predefinedModelsSlice } from '@/store/slices/predefinedModelsSlice'
 import { uploadsSlice } from '@/store/slices/uploadsSlice'
+import { tryOnModeSelector } from '@/store/slices/tryOnSlice'
 import { usePredefinedModels } from './usePredefinedModels'
 import { usePredefinedModelsAnalytics } from './usePredefinedModelsAnalytics'
 import { useTryOnGeneration } from '@/hooks/tryOn/useTryOnGeneration'
@@ -19,9 +20,26 @@ export const usePredefinedModelsSelection = () => {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
   const rpc = useRpc()
-  const { categories, isLoading, isLoaded, isError, isEnabled } = usePredefinedModels()
+  const mode = useAppSelector(tryOnModeSelector)
+  const { categories: allCategories, isLoading, isLoaded, isError, isEnabled } = usePredefinedModels()
   const { startTryOn } = useTryOnGeneration()
   const { trackCategoryChange, trackModelSelected } = usePredefinedModelsAnalytics()
+
+  // General mode shows only full-height models in the classic picker — the
+  // bird/side-view models are shoe angles, surfaced only by the shoes grouped
+  // picker. Untagged (legacy) models are treated as full-height. Shoes mode
+  // keeps every view and groups them in the UI.
+  const categories = useMemo(() => {
+    if (mode === 'shoes') return allCategories
+    return allCategories
+      .map((category) => ({
+        ...category,
+        models: category.models.filter(
+          (model) => !model.tags?.view || model.tags.view === 'full-height',
+        ),
+      }))
+      .filter((category) => category.models.length > 0)
+  }, [allCategories, mode])
 
   // Get preferred category from config
   const preferredCategoryId =

--- a/app/src/hooks/pageBar/usePageBarVisibility.ts
+++ b/app/src/hooks/pageBar/usePageBarVisibility.ts
@@ -2,6 +2,7 @@ import { useLocation } from 'react-router-dom'
 import { useAppSelector } from '@/store/store'
 import { qrTokenSelector } from '@/store/slices/qrSlice'
 import { isMobileSelector } from '@/store/slices/appSlice'
+import { tryOnModeSelector } from '@/store/slices/tryOnSlice'
 import { generationsIsSelectingSelector } from '@/store/slices/generationsSlice'
 import { uploadsIsSelectingSelector } from '@/store/slices/uploadsSlice'
 import { useGenerationsData, useUploadsData } from '@/hooks/data'
@@ -12,6 +13,7 @@ export const usePageBarVisibility = () => {
 
   const qrToken = useAppSelector(qrTokenSelector)
   const isMobile = useAppSelector(isMobileSelector)
+  const mode = useAppSelector(tryOnModeSelector)
   const { data: generatedImages = [] } = useGenerationsData()
   const { data: recentlyPhotos = [] } = useUploadsData()
   const isSelectingGenerations = useAppSelector(generationsIsSelectingSelector)
@@ -43,9 +45,11 @@ export const usePageBarVisibility = () => {
     !showBackButton && !isOnOnboardingPage && !isOnHomePage && hasGeneratedImages
 
   // Title visibility: the onboarding navbar has no title (close button only);
-  // on mobile the models page puts its Women/Men segmented control in the
-  // navbar center instead of the title (see ModelsMobile)
-  const showTitle = !isOnOnboardingPage && !(isOnModelsPage && isMobile)
+  // on mobile the general models page puts its Women/Men segmented control in
+  // the navbar center instead of the title (see ModelsMobile). Shoes mode keeps
+  // the title ("Select example") since its gender toggle lives in the content.
+  const isShoes = mode === 'shoes'
+  const showTitle = !isOnOnboardingPage && !(isOnModelsPage && isMobile && !isShoes)
 
   // Right side content visibility
   const showSelectButton = isOnHistoryPage && hasAnyHistory

--- a/app/src/hooks/strings/usePredefinedModelsStrings.ts
+++ b/app/src/hooks/strings/usePredefinedModelsStrings.ts
@@ -18,6 +18,13 @@ const DEFAULT_CATEGORY_LABELS: Record<string, string> = {
   male: 'Men',
 }
 
+// Default labels for the shoes view groups (Figma)
+const DEFAULT_VIEW_LABELS: Record<string, string> = {
+  'full-height': 'Full height models',
+  'bird-view': 'Bird view angle',
+  'side-view': 'Side view',
+}
+
 /**
  * Hook for getting localized Predefined Models feature strings with fallbacks
  */
@@ -30,6 +37,7 @@ export const usePredefinedModelsStrings = () => {
   const shoesStrings = rpc.config.modes?.shoes?.imagePicker?.predefinedModels?.strings
   const categoryMap = strings?.predefinedModelCategories || {}
   const shoesCategoryMap = shoesStrings?.predefinedModelShoesCategories || {}
+  const shoesGroupMap = shoesStrings?.predefinedModelShoesGroups || {}
 
   const isShoes = mode === 'shoes'
 
@@ -45,6 +53,12 @@ export const usePredefinedModelsStrings = () => {
     return categoryMap[categoryId] || DEFAULT_CATEGORY_LABELS[categoryId] || capitalize(categoryId)
   }
 
+  /**
+   * Get the localized label for a shoes view group (full-height/bird-view/side-view)
+   */
+  const getViewLabel = (view: string): string =>
+    shoesGroupMap[view] || DEFAULT_VIEW_LABELS[view] || capitalize(view)
+
   return {
     // In shoes mode the user picks an example photo rather than a model;
     // the same string labels the picker buttons and the /models page title
@@ -55,5 +69,6 @@ export const usePredefinedModelsStrings = () => {
     predefinedModelsEmptyListError:
       strings?.predefinedModelsEmptyListError ?? 'The models list is empty',
     getCategoryName,
+    getViewLabel,
   }
 }

--- a/app/src/pages/8-PredefinedModels/ModelsShoes.tsx
+++ b/app/src/pages/8-PredefinedModels/ModelsShoes.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect } from 'react'
+import { Spinner, PrimaryButton, Tabs, ModelsGroups } from '@/components'
+import {
+  usePredefinedModelsSelection,
+  usePredefinedModelsStrings,
+  usePredefinedModelsAnalytics,
+} from '@/hooks'
+import { groupModelsByView } from '@/utils/models/groupModelsByView'
+import styles from './Models.module.scss'
+
+/**
+ * Shoes mode model picker: a Women/Men gender toggle over a grouped list of
+ * models (by camera view), each group a horizontally-scrolling row. Tapping a
+ * card starts the try-on directly — no preview or Try On button (Figma).
+ */
+export default function ModelsShoes() {
+  const {
+    categories,
+    currentCategory,
+    selectedCategoryId,
+    isLoading,
+    isError,
+    handleCategoryChange,
+    handleModelSelect,
+    handleRetry,
+  } = usePredefinedModelsSelection()
+
+  const { predefinedModelsEmptyListError, getCategoryName, getViewLabel } =
+    usePredefinedModelsStrings()
+
+  const { trackModelsPageView } = usePredefinedModelsAnalytics()
+
+  // Track page view on mount
+  useEffect(() => {
+    trackModelsPageView()
+  }, [trackModelsPageView])
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <main className={styles.models}>
+        <Spinner isVisible={true} />
+      </main>
+    )
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <main className={styles.models}>
+        <div className={styles.errorState}>
+          <p className="aiuta-label-regular">{predefinedModelsEmptyListError}</p>
+          <PrimaryButton onClick={handleRetry} shape="S">
+            Try again
+          </PrimaryButton>
+        </div>
+      </main>
+    )
+  }
+
+  // Empty state
+  if (categories.length === 0 || !currentCategory) {
+    return (
+      <main className={styles.models}>
+        <div className={styles.emptyState}>
+          <p className="aiuta-label-regular">{predefinedModelsEmptyListError}</p>
+        </div>
+      </main>
+    )
+  }
+
+  const tabs = categories.map((cat) => ({
+    id: cat.category,
+    label: getCategoryName(cat.category),
+  }))
+
+  const groups = groupModelsByView(currentCategory.models).map((group) => ({
+    view: group.view,
+    label: getViewLabel(group.view),
+    models: group.models,
+  }))
+
+  return (
+    <main className={styles.models}>
+      <Tabs
+        tabs={tabs}
+        activeTabId={selectedCategoryId || categories[0].category}
+        onTabChange={handleCategoryChange}
+        className={styles.tabs}
+      />
+
+      {groups.length > 0 ? (
+        <ModelsGroups groups={groups} onModelSelect={handleModelSelect} />
+      ) : (
+        <div className={styles.emptyState}>
+          <p className="aiuta-label-regular">{predefinedModelsEmptyListError}</p>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/app/src/pages/8-PredefinedModels/index.tsx
+++ b/app/src/pages/8-PredefinedModels/index.tsx
@@ -1,19 +1,26 @@
 import React from 'react'
 import { useAppSelector } from '@/store/store'
 import { isMobileSelector } from '@/store/slices/appSlice'
+import { tryOnModeSelector } from '@/store/slices/tryOnSlice'
 import ModelsDesktop from './ModelsDesktop'
 import ModelsMobile from './ModelsMobile'
+import ModelsShoes from './ModelsShoes'
 
 /**
  * PredefinedModelsPage - displays predefined models for selection
  *
- * Features:
- * - Category tabs
- * - Model gallery (desktop) or horizontal list (mobile)
- * - Loading/Error/Empty states
+ * - Shoes mode: a grouped picker (gender toggle + view groups), same on both
+ *   breakpoints
+ * - General mode: category tabs with a gallery (desktop) or a horizontal list
+ *   with a preview (mobile)
  */
 export default function PredefinedModelsPage() {
   const isMobile = useAppSelector(isMobileSelector)
+  const mode = useAppSelector(tryOnModeSelector)
+
+  if (mode === 'shoes') {
+    return <ModelsShoes />
+  }
 
   return isMobile ? <ModelsMobile /> : <ModelsDesktop />
 }

--- a/app/src/utils/api/index.ts
+++ b/app/src/utils/api/index.ts
@@ -3,6 +3,7 @@ export {
   type ApiAuthParams,
   type InputImage,
   type GenerationResult,
+  type TryOnModel,
   type PredefinedModelCategory,
   type PredefinedModelsResponse,
 } from './tryOnApiService'

--- a/app/src/utils/api/tryOnApiService.ts
+++ b/app/src/utils/api/tryOnApiService.ts
@@ -43,15 +43,18 @@ export interface TryOnModel extends InputImage {
   owner_type?: string
   tags?: {
     gender?: 'male' | 'female' | 'unisex'
+    /** Shoes mode groups the models by camera view */
+    view?: 'full-height' | 'bird-view' | 'side-view'
   }
 }
 
 /**
- * Predefined model category with associated models
+ * Predefined model category with associated models. Models keep their tags
+ * (the shoes picker groups them further by `view`).
  */
 export interface PredefinedModelCategory {
   category: string
-  models: InputImage[]
+  models: TryOnModel[]
 }
 
 // The flat unified models list is grouped into the fixed gender categories

--- a/app/src/utils/models/groupModelsByView.ts
+++ b/app/src/utils/models/groupModelsByView.ts
@@ -1,0 +1,22 @@
+import type { TryOnModel } from '@/utils/api'
+
+export type ModelView = 'full-height' | 'bird-view' | 'side-view'
+
+export interface ModelViewGroup {
+  view: ModelView
+  models: TryOnModel[]
+}
+
+// Fixed render order of the shoes view groups (Figma)
+const VIEW_ORDER: ModelView[] = ['full-height', 'bird-view', 'side-view']
+
+/**
+ * Group a gender category's models by their `view` tag, in the fixed Figma
+ * order. Models without a recognized view are dropped, and empty groups are
+ * omitted.
+ */
+export const groupModelsByView = (models: TryOnModel[]): ModelViewGroup[] =>
+  VIEW_ORDER.map((view) => ({
+    view,
+    models: models.filter((model) => model.tags?.view === view),
+  })).filter((group) => group.models.length > 0)

--- a/lib/config/modes.ts
+++ b/lib/config/modes.ts
@@ -46,6 +46,8 @@ export interface ShoesImagePicker {
     strings?: {
       predefinedModelShoesPageTitle?: string
       predefinedModelShoesCategories?: Record<string, string>
+      /** Labels for the view groups, keyed by view (full-height/bird-view/side-view) */
+      predefinedModelShoesGroups?: Record<string, string>
     }
   }
   images?: {


### PR DESCRIPTION
## Summary

Models now carry `gender` and `view` (`full-height`/`bird-view`/`side-view`) tags. Shoes mode gets a grouped model picker; general mode keeps the classic one but limited to full-height models.

**Shoes mode** (Figma desktop `12764-36658`, mobile `12469-21674`)
- Women/Men gender toggle over a vertical list of view groups (Full height models / Bird view angle / Side view), each a horizontally-scrolling row of thumbnails.
- Desktop shows per-row arrow buttons; mobile is touch-scroll and makes the full-height cards larger than the other views.
- Tapping a card starts the try-on directly (no preview / Try On button).
- Navbar shows the "Select example" title (no tabs overlay).

**General mode**
- Unchanged classic picker, but now shows only full-height models (bird/side-view are shoe angles); untagged models are treated as full-height.

## Implementation
- `TryOnModel.tags.view` + `PredefinedModelCategory.models: TryOnModel[]`; `groupModelsByView` util.
- `getViewLabel` with config overrides (`predefinedModelShoesGroups`), defaults `Full height models / Bird view angle / Side view`.
- New `ModelsGroups` component + `ModelsShoes` page; `index.tsx` branches on `tryOnModeSelector`.
- `usePredefinedModelsSelection` filters general mode to full-height; `usePageBarVisibility` keeps the title on shoes mobile `/models`.

## Test plan
- `npm run lint` (eslint + `tsc --noEmit`) passes
- General `/models` unchanged (desktop grid, mobile preview+list+Try On), full-height only
- Shoes `/models`: gender toggle, three view groups with horizontal scroll, desktop arrows, mobile larger full-height cards, tap → try-on
- Group labels / gender labels config-overridable

Note: shoes groups need real model data tagged with `view` to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)