### PR TITLE
Shoes tweaks: model rows, smart fit, demo sort, QR selection

### DIFF
--- a/app/src/components/images/CrossFadeImage/CrossFadeImage.tsx
+++ b/app/src/components/images/CrossFadeImage/CrossFadeImage.tsx
@@ -7,7 +7,7 @@ import styles from './CrossFadeImage.module.scss'
 const MAX_WIDTH_CROP = 1 / 4
 // Side bars this thin (per side) read as an artifact rather than a frame,
 // so a barely-narrower image is covered (cropping a bit of height) instead
-const MAX_SIDE_BAR_PX = 20
+const MAX_SIDE_BAR_PX = 0
 
 /**
  * Picks how to fit an image of the given aspect ratio (width/height) into

--- a/app/src/components/picker/ModelsGroups/ModelsGroups.module.scss
+++ b/app/src/components/picker/ModelsGroups/ModelsGroups.module.scss
@@ -1,4 +1,5 @@
-// Vertical scroller of view groups
+// Vertical scroller of view groups — full width; the 8px side inset lives on
+// the labels and inside each row's scroller (so rows scroll edge-to-edge)
 .groups {
   flex: 1 1 0;
   min-height: 0;
@@ -7,7 +8,7 @@
   display: flex;
   flex-direction: column;
   gap: 24px;
-  padding: 0 8px 8px;
+  padding: 0 0 8px;
 
   &::-webkit-scrollbar {
     display: none;
@@ -16,7 +17,7 @@
 }
 
 .groupLabel {
-  margin: 0 0 8px;
+  margin: 0 8px 8px;
   color: var(--aiuta-color-secondary);
 }
 
@@ -24,19 +25,28 @@
   position: relative;
 }
 
-// Horizontal scroller of model cards
+// Horizontal scroller of model cards. The scroller spans the full width so the
+// cards scroll edge-to-edge. Zero-width flex items at both ends turn the row
+// `gap` into an 8px inset before the first and after the last card — reliable
+// in scroll containers, where edge padding/margin can be dropped.
 .row {
   display: flex;
   gap: 8px;
   overflow-x: auto;
   overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
-  scroll-snap-type: x proximity;
 
   &::-webkit-scrollbar {
     display: none;
   }
   scrollbar-width: none;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 0 0 auto;
+    width: 0;
+  }
 }
 
 // Figma model card: 153×240, 16px radius (from the M image shape). Relative so
@@ -49,7 +59,6 @@
   width: 153px;
   height: 240px;
   cursor: pointer;
-  scroll-snap-align: start;
 }
 
 @media (max-width: 992px) {
@@ -84,9 +93,9 @@
 }
 
 .arrow_left {
-  left: -4px;
+  left: 4px;
 }
 
 .arrow_right {
-  right: -4px;
+  right: 4px;
 }

--- a/app/src/hooks/tryOn/useSelectedUploadSync.ts
+++ b/app/src/hooks/tryOn/useSelectedUploadSync.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store/store'
 import { tryOnSlice, selectedImageSelector, isGeneratingSelector } from '@/store/slices/tryOnSlice'
 import { useUploadsData } from '@/hooks/data'
@@ -7,40 +7,47 @@ import { isInputImage } from '@/models'
 /**
  * Keeps the previewed image in sync with the uploads list on the try-on page:
  * - nothing selected and photos exist → preview the most recent
- * - the selected upload was deleted → preview the next one, or fall back to the
+ * - the selected upload is removed → preview the next one, or fall back to the
  *   empty state when none remain
  *
- * A freshly picked (not-yet-uploaded) NewImage is left untouched. This replaces
- * the bare "auto-select most recent" effect, which could re-select a just
- * deleted photo (the uploads cache lags one tick behind the cleared selection)
- * and then never drop it — leaving a deleted image stuck in the picker.
+ * Reconciliation only fires when the selected upload was actually removed from
+ * the list (present before, gone now). A selection that was never in the local
+ * list is left untouched — a freshly picked NewImage, or an image set
+ * externally (a QR upload, a predefined model). Otherwise those would be
+ * clobbered, e.g. a QR upload replaced by the last used photo, or cleared when
+ * there are no local uploads yet.
  */
 export const useSelectedUploadSync = () => {
   const dispatch = useAppDispatch()
   const selectedImage = useAppSelector(selectedImageSelector)
   const isGenerating = useAppSelector(isGeneratingSelector)
   const { data: recentPhotos = [] } = useUploadsData()
+  const prevUploadIdsRef = useRef<Set<string>>(new Set())
 
   useEffect(() => {
-    // While generating, the selection is the just-uploaded image that is not in
-    // the uploads list yet (it's added when generation finishes) — leave it so
-    // the loading view stays put
-    if (isGenerating) return
+    const uploadIds = new Set(recentPhotos.map((photo) => photo.id))
 
-    // A picked-but-not-uploaded image isn't part of the uploads list — keep it
-    if (selectedImage && !isInputImage(selectedImage)) return
-
-    const selectedStillExists =
-      !!selectedImage &&
-      isInputImage(selectedImage) &&
-      recentPhotos.some((photo) => photo.id === selectedImage.id)
-
-    if (selectedStillExists) return
-
-    if (recentPhotos.length > 0) {
-      dispatch(tryOnSlice.actions.setSelectedImage(recentPhotos[0]))
-    } else if (selectedImage) {
-      dispatch(tryOnSlice.actions.clearSelectedImage())
+    // While generating, the selection is the just-uploaded image not yet in the
+    // uploads list — leave it so the loading view stays put
+    if (!isGenerating) {
+      if (!selectedImage) {
+        // Nothing selected: preview the most recent upload, if any
+        if (recentPhotos.length > 0) {
+          dispatch(tryOnSlice.actions.setSelectedImage(recentPhotos[0]))
+        }
+      } else if (isInputImage(selectedImage)) {
+        const wasRemoved =
+          prevUploadIdsRef.current.has(selectedImage.id) && !uploadIds.has(selectedImage.id)
+        if (wasRemoved) {
+          if (recentPhotos.length > 0) {
+            dispatch(tryOnSlice.actions.setSelectedImage(recentPhotos[0]))
+          } else {
+            dispatch(tryOnSlice.actions.clearSelectedImage())
+          }
+        }
+      }
     }
+
+    prevUploadIdsRef.current = uploadIds
   }, [selectedImage, recentPhotos, isGenerating, dispatch])
 }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -45,7 +45,10 @@ export default function App() {
     const offset = paging.nextOffset
     try {
       const page = await fetchSkuPage(offset)
-      setSkus((prev) => (offset === 0 ? page.items : [...prev, ...page.items]).sort(byCatalogOrder))
+      // Sort within the page only and append — re-sorting the whole list on
+      // every page would reshuffle already-shown items as more load
+      const sortedPage = [...page.items].sort(byCatalogOrder)
+      setSkus((prev) => (offset === 0 ? sortedPage : [...prev, ...sortedPage]))
       paging.nextOffset = page.nextOffset
       setHasMoreSkus(page.nextOffset !== null)
     } catch (error) {


### PR DESCRIPTION
## Summary

Small fixes on top of the shoes work.

- **Model group rows scroll edge-to-edge** — the shoes view-group rows were inset by the container padding and didn't reach the edges. Rows are now full-width with an even 8px inset inside the scroller (zero-width flex spacers + gap); dropped scroll-snap, which snapped the first card to the left edge and ate the left inset (the asymmetric "right inset only" look).
- **Smart image fit** — always crop thin side bars (`MAX_SIDE_BAR_PX` → 0) instead of showing a thin frame.
- **Demo catalog sort** — sort within each page and append, so already-shown items don't reshuffle as more pages load.
- **QR upload selection (desktop)** — a QR upload was being replaced by the last used photo: `useSelectedUploadSync` reshuffled any selection not in the local uploads list. It now reconciles only on an actual removal (selected id was in the list and is now gone), so QR uploads and predefined models survive (including with no local uploads), while delete-last still falls back to the empty state.

## Test plan
- `npm run lint` (eslint + `tsc --noEmit`) and `npm run build:demo` pass
- Shoes `/models` rows scroll to the edges with equal side insets
- Demo catalog doesn't jump while paginating
- Desktop QR upload applies the scanned photo (with and without prior local uploads); deleting the last history photo returns to the empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)