### PR TITLE
Shoes tweaks 3: QR fullscreen, share gating, back-arrow nav, sheet reset

### DIFF
--- a/app/src/components/index.ts
+++ b/app/src/components/index.ts
@@ -2,6 +2,7 @@
 
 // General UI
 export { AppContainer } from './ui/AppContainer'
+export { Shell } from './ui/Shell'
 export { PageBar } from './ui/PageBar'
 export { PoweredBy } from './ui/PoweredBy'
 export { Icon } from './ui/Icon'

--- a/app/src/components/ui/AppContainer/AppContainer.tsx
+++ b/app/src/components/ui/AppContainer/AppContainer.tsx
@@ -7,14 +7,17 @@ import styles from './AppContainer.module.scss'
 
 interface AppContainerProps {
   children: React.ReactNode
+  /** Always use the mobile fullscreen layout, regardless of width (QR upload) */
+  fullscreen?: boolean
 }
 
 /**
  * App container that handles app sizing and positioning
  */
-export const AppContainer = ({ children }: AppContainerProps) => {
+export const AppContainer = ({ children, fullscreen }: AppContainerProps) => {
   useWindowResize()
-  const isMobile = useAppSelector(isMobileSelector)
+  const isMobileWidth = useAppSelector(isMobileSelector)
+  const isMobile = fullscreen || isMobileWidth
   const isVisible = useAppSelector(isAppVisibleSelector)
   const containerRef = useRef<HTMLDivElement | null>(null)
   // Keep the host page from scrolling: a wheel over the panel is contained on

--- a/app/src/components/ui/Shell/Shell.module.scss
+++ b/app/src/components/ui/Shell/Shell.module.scss
@@ -1,8 +1,8 @@
 // Small-screen scaling for the whole SDK shell — the panel AND every overlay
-// (share, fullscreen gallery, confirmation, alerts). It lives here rather than
-// on AppContainer so the overlays, which are rendered as siblings, scale too.
-// Only the mobile fullscreen layout scales; the desktop floating panel uses its
-// own size clamps instead.
+// (share, fullscreen gallery, confirmation, alerts). It lives on the shell
+// rather than on AppContainer so the overlays, which are rendered as siblings,
+// scale too. Callers enable it only for fullscreen layouts (mobile / the QR
+// upload page); the desktop floating panel uses its own size clamps instead.
 //
 // Implemented with `transform: scale` (not `zoom`): the shell is over-sized by
 // 1/scale and scaled back down, so it still fills the viewport AND reflows the
@@ -10,7 +10,7 @@
 // viewport units and leaves the panel shrunk; transform doesn't). The transform
 // also makes the shell the containing block for its fixed children, which is why
 // the full-screen elements inside use `%` (of the shell) instead of vw/vh.
-.shell_mobile {
+.shell_scaled {
   --aiuta-zoom: 1;
   position: fixed;
   top: 0;

--- a/app/src/components/ui/Shell/Shell.tsx
+++ b/app/src/components/ui/Shell/Shell.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { combineClassNames } from '@/utils'
+import styles from './Shell.module.scss'
+
+interface ShellProps {
+  children: React.ReactNode
+  /**
+   * Scale the whole shell (panel + overlays) down on small screens. Enable it
+   * for fullscreen layouts (mobile, the QR upload page); leave it off for the
+   * desktop floating panel, which clamps its own size instead.
+   */
+  scaled?: boolean
+}
+
+/**
+ * Wraps the app UI so the panel and its fixed overlays scale together on small
+ * screens (see Shell.module.scss).
+ */
+export const Shell = ({ children, scaled }: ShellProps) => (
+  <div className={combineClassNames(scaled && styles.shell_scaled)}>{children}</div>
+)

--- a/app/src/components/ui/Shell/index.ts
+++ b/app/src/components/ui/Shell/index.ts
@@ -1,0 +1,1 @@
+export { Shell } from './Shell'

--- a/app/src/hooks/app/useRpcInitialization.ts
+++ b/app/src/hooks/app/useRpcInitialization.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAppDispatch, useAppSelector } from '@/store/store'
 import { appSlice } from '@/store/slices/appSlice'
 import { tryOnSlice } from '@/store/slices/tryOnSlice'
+import { uploadsSlice } from '@/store/slices/uploadsSlice'
 import { isAppVisibleSelector } from '@/store/slices/appSlice'
 import { useAlert, useLogger } from '@/contexts'
 import { AiutaAppRpc } from '@lib/rpc'
@@ -44,6 +45,10 @@ export const useRpcInitialization = () => {
         const showApp = () => {
           // Close any active alerts when showing app
           closeAlert()
+
+          // Reset transient picker UI so a fresh open never restores a sheet
+          // that was left open in a previous session (e.g. "Change photo")
+          dispatch(uploadsSlice.actions.setIsBottomSheetOpen(false))
 
           // Always navigate to home when showing the app, clearing history
           navigate('/', { replace: true })

--- a/app/src/hooks/gallery/useUploadsGallery.ts
+++ b/app/src/hooks/gallery/useUploadsGallery.ts
@@ -59,7 +59,9 @@ export const useUploadsGallery = ({
           url: image.url,
         }),
       )
-      navigate('/tryon')
+      // Replace: /tryon (and the result that follows) has no back button, so
+      // consume the picker entry instead of stacking it
+      navigate('/tryon', { replace: true })
     }
     // In selection mode, SelectableImage handles the click
   }
@@ -123,16 +125,19 @@ export const useUploadsGallery = ({
   const handlePhotoUpload = useCallback(
     async (file: File) => {
       await selectImageToTryOn(file)
-      // Navigate to try-on page after successful selection
-      navigate('/tryon')
+      // Navigate to try-on page after successful selection (replace: the picker
+      // entry is consumed, not stacked — /tryon has no back button)
+      navigate('/tryon', { replace: true })
     },
     [selectImageToTryOn, navigate],
   )
 
   // Navigate to upload page
   const navigateToUpload = useCallback(() => {
-    // Always go to QR page when user explicitly wants to upload
-    navigate('/qr')
+    // Always go to QR page when user explicitly wants to upload. Mark it
+    // returnable so the page bar shows a back arrow (not the history icon) —
+    // we routed here from the picker, so there is somewhere to go back to.
+    navigate('/qr', { state: { canGoBack: true } })
   }, [navigate])
 
   // Get most recent photo

--- a/app/src/hooks/models/usePredefinedModelsSelection.ts
+++ b/app/src/hooks/models/usePredefinedModelsSelection.ts
@@ -124,8 +124,9 @@ export const usePredefinedModelsSelection = () => {
       // Close bottom sheet if open
       dispatch(uploadsSlice.actions.setIsBottomSheetOpen(false))
 
-      // Navigate to try-on page
-      navigate('/tryon')
+      // Navigate to try-on page (replace: the picker entry is consumed, not
+      // stacked — /tryon and the result that follows have no back button)
+      navigate('/tryon', { replace: true })
 
       // Start try-on with selected model
       await startTryOn(model)

--- a/app/src/hooks/pageBar/usePageBarNavigation.ts
+++ b/app/src/hooks/pageBar/usePageBarNavigation.ts
@@ -72,6 +72,12 @@ export const usePageBarNavigation = () => {
   }
 
   const handleHistoryNavigation = (targetPath: string) => {
+    // QR prompt reached via "Add new" → the left button is a back arrow
+    if (pathName === '/qr' && (location.state as { canGoBack?: boolean } | null)?.canGoBack) {
+      navigate(-1)
+      return
+    }
+
     const isOnHistoryPage = pathName === '/generations' || pathName === '/uploads'
     const isOnModelsPage = pathName === '/models'
 

--- a/app/src/hooks/pageBar/usePageBarVisibility.ts
+++ b/app/src/hooks/pageBar/usePageBarVisibility.ts
@@ -27,6 +27,11 @@ export const usePageBarVisibility = () => {
   const isOnQrTokenPage = qrToken ? pathName.includes(qrToken) : false
   const isOnOnboardingPage = pathName === '/onboarding'
   const isOnModelsPage = pathName === '/models'
+  // The QR prompt is both an entry screen (from onboarding) and an "Add new"
+  // destination. Only the latter is routed with { canGoBack }, where the left
+  // button must be a back arrow instead of the history icon.
+  const isReturnableQrPage =
+    pathName === '/qr' && !!(location.state as { canGoBack?: boolean } | null)?.canGoBack
 
   // Data availability
   const hasGeneratedImages = generatedImages.length > 0
@@ -37,8 +42,10 @@ export const usePageBarVisibility = () => {
   const isAnySelectionActive = isSelectingGenerations || isSelectingUploads
 
   // Navigation buttons logic (simplified)
-  // 1. Back button: always show on /generations, /uploads, /models (but not on home page)
-  const showBackButton = isOnBackButtonPage && !isOnQrTokenPage && !isOnHomePage
+  // 1. Back button: always show on /generations, /uploads, /models, and on the
+  // QR prompt when it was reached via "Add new" (but not on home page)
+  const showBackButton =
+    (isOnBackButtonPage || isReturnableQrPage) && !isOnQrTokenPage && !isOnHomePage
 
   // 2. History button: show only if NOT showing back button, NOT on onboarding, NOT on home page, and have images
   const showHistoryButton =

--- a/app/src/hooks/picker/useGlobalFileDrop.ts
+++ b/app/src/hooks/picker/useGlobalFileDrop.ts
@@ -27,9 +27,10 @@ export const useGlobalFileDrop = () => {
       // Discard any open alerts without triggering callbacks (e.g., navigate('/'))
       discardAlert()
 
-      // Select image and navigate to try-on page
+      // Select image and navigate to try-on page (replace: the current screen
+      // is consumed, not stacked — /tryon has no back button)
       await selectImageToTryOn(file)
-      navigate('/tryon')
+      navigate('/tryon', { replace: true })
     },
     [isGenerating, discardAlert, selectImageToTryOn, navigate],
   )

--- a/app/src/hooks/picker/useQrPrompt.ts
+++ b/app/src/hooks/picker/useQrPrompt.ts
@@ -57,8 +57,9 @@ export const useQrPrompt = () => {
         // Clean up QR token
         await QrApiService.deleteQrToken(qrToken)
 
-        // Navigate to try-on page
-        navigate('/tryon')
+        // Navigate to try-on page (replace: the picker entry is consumed, not
+        // stacked — /tryon and the result that follows have no back button)
+        navigate('/tryon', { replace: true })
 
         // Stop polling
         stopPolling()

--- a/app/src/hooks/results/useNavigatorShare.ts
+++ b/app/src/hooks/results/useNavigatorShare.ts
@@ -6,10 +6,27 @@ import { useRpc, useLogger, useShare } from '@/contexts'
 import { useGenerationsData } from '@/hooks/data'
 
 /**
- * Hook for sharing a result: native Web Share API when the device supports it,
+ * Whether to use the native Web Share API instead of the in-app modal.
+ *
+ * Desktop browsers advertise `navigator.share`, but the native sheet is
+ * unreliable there — Chrome desktop in incognito, for instance, rejects with
+ * AbortError without ever showing a sheet, so a feature check alone silently
+ * fails. Native share only adds value on real touch/mobile devices, so we gate
+ * on that and let every desktop fall back to the in-app modal.
+ */
+const canUseNativeShare = (): boolean => {
+  if (!navigator.share) return false
+  // Chromium exposes a reliable mobile signal; elsewhere fall back to a
+  // coarse pointer (touchscreen) with no fine pointer (mouse).
+  const ua = (navigator as Navigator & { userAgentData?: { mobile: boolean } }).userAgentData
+  if (ua) return ua.mobile
+  return matchMedia('(pointer: coarse)').matches && !matchMedia('(pointer: fine)').matches
+}
+
+/**
+ * Hook for sharing a result: native Web Share API on touch/mobile devices,
  * otherwise the in-app share modal (copy / WhatsApp / Messenger). The choice is
- * by capability, not viewport width — a narrow desktop window has no native
- * share, so it must fall back instead of silently failing.
+ * by device capability, not viewport width.
  */
 export const useNavigatorShare = () => {
   const dispatch = useAppDispatch()
@@ -25,8 +42,9 @@ export const useNavigatorShare = () => {
       const urlToShare = imageUrl || generatedImages[0]?.url
       if (!urlToShare) return
 
-      // No native Web Share API (e.g. desktop) → use the in-app share modal
-      if (!navigator.share) {
+      // Not a device where native share is reliable (e.g. any desktop) → use
+      // the in-app share modal
+      if (!canUseNativeShare()) {
         openShareModal(urlToShare)
         return
       }

--- a/app/src/hooks/tryOn/useTryOnGeneration.ts
+++ b/app/src/hooks/tryOn/useTryOnGeneration.ts
@@ -152,7 +152,11 @@ export const useTryOnGeneration = () => {
 
         // Common logic after navigation
         const finalizeGeneration = () => {
-          navigate('/results')
+          // Replace: a result is the end of a generation cycle and has no back
+          // button, so it consumes the /tryon (loading) entry instead of
+          // stacking — together with the picker→/tryon replaces this keeps the
+          // history from growing on every generation.
+          navigate('/results', { replace: true })
 
           // After navigation, add images to history (background, slow storage)
           addGeneration(generatedImage)

--- a/app/src/hooks/tryOn/useTryOnWithOtherPhoto.ts
+++ b/app/src/hooks/tryOn/useTryOnWithOtherPhoto.ts
@@ -41,8 +41,10 @@ export const useTryOnWithOtherPhoto = () => {
         // Mobile: open bottom sheet without image selection (shows only buttons)
         dispatch(uploadsSlice.actions.setIsBottomSheetOpen(true))
       } else {
-        // Desktop: navigate to QR page
-        navigate('/qr')
+        // Desktop: navigate to QR page. Mark it returnable so the page bar
+        // shows a back arrow (not the history icon) — we routed here from
+        // "Add new", so there is somewhere to go back to.
+        navigate('/qr', { state: { canGoBack: true } })
       }
     }
   }, [hasMultiplePhotos, isMobile, navigate, dispatch])

--- a/app/src/pages/2-QrPrompt/QrPromptDesktop.tsx
+++ b/app/src/pages/2-QrPrompt/QrPromptDesktop.tsx
@@ -53,7 +53,10 @@ export default function QrPromptDesktop() {
   const handleFileSelect = useCallback(
     async (file: File) => {
       await selectImageToTryOn(file)
-      navigate('/tryon')
+      // Replace: /tryon (and the result that follows) has no back button, so
+      // the picker entry that led here should be consumed, not stacked. This
+      // keeps the "Add new" loop from growing the history on every generation.
+      navigate('/tryon', { replace: true })
     },
     [selectImageToTryOn, navigate],
   )

--- a/app/src/pages/5-Results/ResultsMobile.tsx
+++ b/app/src/pages/5-Results/ResultsMobile.tsx
@@ -55,7 +55,9 @@ export default function ResultsMobile() {
     async (file: File) => {
       dispatch(uploadsSlice.actions.setIsBottomSheetOpen(false))
       const newImage = await selectImageToTryOn(file)
-      navigate('/tryon')
+      // Replace: /tryon and the result that follows have no back button, so the
+      // current results entry is consumed instead of stacked
+      navigate('/tryon', { replace: true })
       startTryOn(newImage)
     },
     [dispatch, navigate, selectImageToTryOn, startTryOn],
@@ -66,7 +68,8 @@ export default function ResultsMobile() {
       const imageToTryOn = { id, url }
       dispatch(tryOnSlice.actions.setSelectedImage(imageToTryOn))
       dispatch(uploadsSlice.actions.setIsBottomSheetOpen(false))
-      navigate('/tryon')
+      // Replace: see handleFileSelect — consume the results entry, don't stack
+      navigate('/tryon', { replace: true })
       startTryOn(imageToTryOn)
     },
     [dispatch, navigate, startTryOn],

--- a/app/src/routing/MainApp.tsx
+++ b/app/src/routing/MainApp.tsx
@@ -9,7 +9,14 @@ import {
   StorageProvider,
   QueryProvider,
 } from '@/contexts'
-import { PageBar, FullScreenGallery, Share, AppContainer, ConfigError } from '@/components'
+import {
+  PageBar,
+  FullScreenGallery,
+  Share,
+  AppContainer,
+  ConfigError,
+  Shell,
+} from '@/components'
 import {
   useUrlParams,
   useCustomCssUrl,
@@ -22,7 +29,6 @@ import {
 
 import { useAppSelector } from '@/store/store'
 import { isMobileSelector } from '@/store/slices/appSlice'
-import { combineClassNames } from '@/utils'
 import { ClearStorageBridge } from '@/components/debug/ClearStorageBridge'
 import HomePageRouter from '@/pages/Home'
 import OnboardingPage from '@/pages/1-Onboarding'
@@ -31,7 +37,6 @@ import TryOnPage from '@/pages/4-TryOn'
 import ResultsPage from '@/pages/5-Results'
 import GenerationsHistoryPage from '@/pages/6-GenerationsHistory'
 import UploadsHistoryPage from '@/pages/7-UploadsHistory'
-import styles from './MainApp.module.scss'
 import PredefinedModelsPage from '@/pages/8-PredefinedModels'
 
 /**
@@ -109,9 +114,9 @@ function AppContent() {
   return (
     <DragAndDropProvider>
       <ClearStorageBridge />
-      {/* The shell scales down on small screens (mobile only); keeping the zoom
-          here means the overlays below scale with the panel, not just it */}
-      <div className={combineClassNames(styles.shell, isMobile && styles.shell_mobile)}>
+      {/* Scale the panel and its overlays together on small screens (mobile
+          only; the desktop floating panel clamps its own size instead) */}
+      <Shell scaled={isMobile}>
         <AppContainer>
           <AlertRenderer />
           <PageBar />
@@ -129,7 +134,7 @@ function AppContent() {
 
         <FullScreenGallery />
         <Share />
-      </div>
+      </Shell>
     </DragAndDropProvider>
   )
 }

--- a/app/src/routing/MainApp/index.ts
+++ b/app/src/routing/MainApp/index.ts
@@ -1,1 +1,0 @@
-export { MainApp } from './MainApp'

--- a/app/src/routing/QrUpload.tsx
+++ b/app/src/routing/QrUpload.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AppContainer } from '@/components'
+import { AppContainer, Shell } from '@/components'
 import { useUrlParams, useCustomCssUrl, useStandaloneApp } from '@/hooks'
 import QrUploadPage from '@/pages/3-QrUpload'
 
@@ -19,9 +19,13 @@ export const QrUpload = () => {
   }
 
   return (
-    <AppContainer>
-      {/* PoweredBy is rendered inside the page — it depends on the upload state */}
-      <QrUploadPage />
-    </AppContainer>
+    // The QR upload page is always a mobile fullscreen layout, so it scales
+    // down on small screens like the main app shell.
+    <Shell scaled>
+      <AppContainer fullscreen>
+        {/* PoweredBy is rendered inside the page — it depends on the upload state */}
+        <QrUploadPage />
+      </AppContainer>
+    </Shell>
   )
 }

--- a/app/src/routing/QrUpload/index.ts
+++ b/app/src/routing/QrUpload/index.ts
@@ -1,1 +1,0 @@
-export { QrUpload } from './QrUpload'


### PR DESCRIPTION
Continuation of share/scaling/navigation polish on top of #102.

## Changes

- **Shared scaling Shell + fullscreen QR upload** — extract the small-screen scaling shell out of `MainApp` into a reusable `Shell` component and apply it to both `MainApp` and the QR upload route, so the QR page downscales the same way. Flatten `routing/` back to a flat structure. Add a `fullscreen` prop to `AppContainer` so the QR upload page always uses the mobile fullscreen layout, never the desktop floating panel.
- **Gate native share to touch devices** — desktop browsers advertise `navigator.share` but the native sheet is unreliable there (Chrome desktop incognito rejects with `AbortError` without ever showing a sheet, so a feature check alone silently fails). Gate native share on a real touch/mobile device (`userAgentData.mobile`, else coarse-only pointer) and let every desktop fall back to the in-app share modal.
- **Back arrow on "Add new" QR prompt + bounded history** — the QR prompt is both an entry screen and an "Add new" destination; routed via "Add new" it showed the history icon with no way back. Mark those navigations with `{ canGoBack }` state and render a back arrow there. Also enter `/tryon` (loading) and `/results` with `replace` (they have no back button), so the "Add new" loop no longer grows the history stack on every generation.
- **Reset uploads bottom sheet on SDK open** — the "Previously used photos" sheet flag persisted in Redux across a close/open, so reopening could show the sheet over the image picker before the user pressed "Change photo". Reset it in `showApp`.

## Verification

`npm run lint` (eslint + tsc) and `npm run build:app` clean. Manually verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)