### PR TITLE
Preload iframe and make RPC handshake resilient

### DIFF
--- a/lib/rpc/clients/app.ts
+++ b/lib/rpc/clients/app.ts
@@ -8,7 +8,7 @@ import type { AppApi, AppContext } from '../api/app'
 import type { InternalSdkApi } from '../protocol/internal'
 import {
   PROTOCOL_VERSION,
-  HANDSHAKE_TIMEOUT,
+  HANDSHAKE_HELLO_RETRY_MS,
   HANDSHAKE_MESSAGE_HELLO,
   HANDSHAKE_MESSAGE_ACK,
 } from '../protocol/core'
@@ -25,6 +25,7 @@ export class AiutaAppRpc extends AiutaRpcBase<AppApi, SdkApi, AppContext> {
   config!: AiutaConfiguration
   private expectedParentOrigin?: string
   private handshakeListener?: (event: MessageEvent) => void
+  private helloRetryTimer?: ReturnType<typeof setInterval>
   private sdkClient?: ReturnType<typeof createRpcClient<InternalSdkApi>>
   private internalSdk!: InternalSdkApi
 
@@ -98,12 +99,12 @@ export class AiutaAppRpc extends AiutaRpcBase<AppApi, SdkApi, AppContext> {
       port: MessagePort
       methodsFromAck?: string[]
     }>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        if (this.handshakeListener) {
-          window.removeEventListener('message', this.handshakeListener)
+      const stopRetry = () => {
+        if (this.helloRetryTimer) {
+          clearInterval(this.helloRetryTimer)
+          this.helloRetryTimer = undefined
         }
-        reject(new Error('App handshake timeout'))
-      }, HANDSHAKE_TIMEOUT)
+      }
 
       this.handshakeListener = (e: MessageEvent) => {
         // Validate origin
@@ -131,12 +132,16 @@ export class AiutaAppRpc extends AiutaRpcBase<AppApi, SdkApi, AppContext> {
         const p = e.ports?.[0]
 
         if (!p) {
-          clearTimeout(timeout)
+          stopRetry()
+          if (this.handshakeListener) {
+            window.removeEventListener('message', this.handshakeListener)
+            this.handshakeListener = undefined
+          }
           reject(new Error('No port in handshake response'))
           return
         }
 
-        clearTimeout(timeout)
+        stopRetry()
         if (this.handshakeListener) {
           window.removeEventListener('message', this.handshakeListener)
           this.handshakeListener = undefined
@@ -152,19 +157,33 @@ export class AiutaAppRpc extends AiutaRpcBase<AppApi, SdkApi, AppContext> {
 
       window.addEventListener('message', this.handshakeListener)
 
-      try {
-        const helloMessage = {
-          type: HANDSHAKE_MESSAGE_HELLO,
-          nonce,
-          version: PROTOCOL_VERSION,
-          appVersion: this._context.appVersion,
-          methods: Object.keys(this.buildRegistry()),
-        }
-        window.parent.postMessage(helloMessage, this.expectedParentOrigin!)
-      } catch (error) {
-        clearTimeout(timeout)
-        reject(new Error(`Failed to send handshake: ${error}`))
+      const helloMessage = {
+        type: HANDSHAKE_MESSAGE_HELLO,
+        nonce,
+        version: PROTOCOL_VERSION,
+        appVersion: this._context.appVersion,
+        methods: Object.keys(this.buildRegistry()),
       }
+
+      const sendHello = () => {
+        try {
+          window.parent.postMessage(helloMessage, this.expectedParentOrigin!)
+        } catch (error) {
+          stopRetry()
+          if (this.handshakeListener) {
+            window.removeEventListener('message', this.handshakeListener)
+            this.handshakeListener = undefined
+          }
+          reject(new Error(`Failed to send handshake: ${error}`))
+        }
+      }
+
+      // Keep broadcasting until the SDK ACKs. With a preloaded iframe the app
+      // boots before the SDK attaches its listener (on the first tryOn), so a
+      // single HELLO would be missed; there is no timeout — the app simply waits
+      // to be activated, and the SDK side has its own handshake timeout.
+      sendHello()
+      this.helloRetryTimer = setInterval(sendHello, HANDSHAKE_HELLO_RETRY_MS)
     })
   }
 
@@ -180,7 +199,11 @@ export class AiutaAppRpc extends AiutaRpcBase<AppApi, SdkApi, AppContext> {
       this.sdkClient = undefined
     }
 
-    // Remove handshake listener
+    // Remove handshake listener and stop any HELLO retries
+    if (this.helloRetryTimer) {
+      clearInterval(this.helloRetryTimer)
+      this.helloRetryTimer = undefined
+    }
     if (this.handshakeListener) {
       window.removeEventListener('message', this.handshakeListener)
       this.handshakeListener = undefined

--- a/lib/rpc/protocol/core.ts
+++ b/lib/rpc/protocol/core.ts
@@ -17,7 +17,15 @@ export type AnyFn = (...args: any[]) => any
 
 export const PROTOCOL_VERSION = '1.0.0'
 export const RPC_TIMEOUT = 15_000
-export const HANDSHAKE_TIMEOUT = 10_000
+// The SDK opens the handshake right after creating the iframe, so this window
+// also has to cover the app bundle downloading and booting inside the iframe —
+// not just the HELLO/ACK round trip. Keep it generous so a slow connection
+// (e.g. throttled mobile) doesn't error out mid-load.
+export const HANDSHAKE_TIMEOUT = 30_000
+// The app re-broadcasts HELLO on this interval until it gets an ACK. With the
+// iframe preloaded, the app boots before the SDK attaches its handshake
+// listener (that happens on the first tryOn), so a single HELLO would be missed.
+export const HANDSHAKE_HELLO_RETRY_MS = 300
 
 /* ---------- Handshake Message Types ---------- */
 

--- a/sdk/aiuta.ts
+++ b/sdk/aiuta.ts
@@ -67,6 +67,14 @@ export default class Aiuta {
     )
 
     this.analytics.track({ type: 'configure' })
+
+    // Preload the iframe so the app bundle downloads and boots in the background
+    // before the first tryOn — on a slow connection this is the difference
+    // between an instant open and waiting (or timing out) on click. The app
+    // re-broadcasts its handshake HELLO until the SDK connects on tryOn.
+    this.iframeManager.ensureIframe().catch((error) => {
+      this.logger.warn('Aiuta iframe preload failed:', error)
+    })
   }
 
   /**

--- a/sdk/handler.ts
+++ b/sdk/handler.ts
@@ -12,6 +12,9 @@ export default class MessageHandler {
   // De-dupes concurrent connects: rapid repeated tryOn calls before the
   // handshake completes must await the same connection, not start new ones
   private connecting?: Promise<void>
+  // Coalesces rapid tryOn calls: only the latest request is forwarded to the app
+  private pendingTryOn?: { productIds: string[]; mode: AiutaMode }
+  private tryOnRunning = false
 
   constructor(
     private readonly analytics: AnalyticsTracker,
@@ -40,15 +43,30 @@ export default class MessageHandler {
   }
 
   async startTryOn(productIds: string[], mode: AiutaMode) {
+    // Always record the latest request. If a run is already in flight, it will
+    // pick this up — only the most recent tryOn reaches the app.
+    this.pendingTryOn = { productIds, mode }
+    if (this.tryOnRunning) return
+
+    this.tryOnRunning = true
     try {
       const iframe = this.iframeManager.getIframe()
-      if (iframe) {
-        await this.ensureConnected(iframe)
-        await this.rpc.app.tryOn(productIds, mode)
+      if (!iframe) return
+
+      await this.ensureConnected(iframe)
+
+      // Drain to the latest pending request (more may have arrived during the
+      // connect / the previous send), so the app always ends on the last one.
+      while (this.pendingTryOn) {
+        const next = this.pendingTryOn
+        this.pendingTryOn = undefined
+        await this.rpc.app.tryOn(next.productIds, next.mode)
       }
     } catch (error) {
       this.logger.error('Aiuta RPC tryOn failed:', error)
       this.analytics.track({ type: 'session', event: 'rpcFailed' })
+    } finally {
+      this.tryOnRunning = false
     }
   }
 

--- a/sdk/handler.ts
+++ b/sdk/handler.ts
@@ -9,6 +9,9 @@ declare const __SDK_VERSION__: string
 
 export default class MessageHandler {
   private rpc: AiutaSdkRpc<AiutaConfiguration>
+  // De-dupes concurrent connects: rapid repeated tryOn calls before the
+  // handshake completes must await the same connection, not start new ones
+  private connecting?: Promise<void>
 
   constructor(
     private readonly analytics: AnalyticsTracker,
@@ -60,14 +63,27 @@ export default class MessageHandler {
   }
 
   private async ensureConnected(iframe: HTMLIFrameElement) {
-    if (!this.rpc.isConnected()) {
-      await this.rpc.connect(iframe)
+    if (this.rpc.isConnected()) return
 
-      if (this.rpc.context.appVersion) {
-        this.analytics.setIframeVersion(this.rpc.context.appVersion)
-      }
-
-      this.analytics.track({ type: 'session', event: 'iframeLoaded' })
+    // Reuse an in-flight connection so concurrent callers don't open parallel
+    // handshakes (which would race over the message port and break RPC). On
+    // failure the promise is cleared so a later call can retry.
+    if (!this.connecting) {
+      this.connecting = this.connect(iframe).finally(() => {
+        this.connecting = undefined
+      })
     }
+
+    await this.connecting
+  }
+
+  private async connect(iframe: HTMLIFrameElement) {
+    await this.rpc.connect(iframe)
+
+    if (this.rpc.context.appVersion) {
+      this.analytics.setIframeVersion(this.rpc.context.appVersion)
+    }
+
+    this.analytics.track({ type: 'session', event: 'iframeLoaded' })
   }
 }

--- a/sdk/iframe.ts
+++ b/sdk/iframe.ts
@@ -18,6 +18,7 @@ export default class IframeManager {
   private customCssUrl?: string
   private hasDebugIframe = false
   private hideTimer: ReturnType<typeof setTimeout> | null = null
+  private creating: Promise<void> | null = null
 
   constructor(
     configuration: AiutaConfiguration,
@@ -45,9 +46,16 @@ export default class IframeManager {
     const existing = document.getElementById(this.iframeId) as HTMLIFrameElement | null
     if (existing) {
       this.iframe = existing
-    } else {
-      await this.createIframe()
+      return
     }
+    // Guard against concurrent calls (preload + an early tryOn) creating the
+    // iframe twice while createIframe is still awaiting (debug URL check).
+    if (!this.creating) {
+      this.creating = this.createIframe().finally(() => {
+        this.creating = null
+      })
+    }
+    await this.creating
   }
 
   setInteractive(interactive: boolean) {


### PR DESCRIPTION
Fixes `tryOn` failing with `SDK handshake timeout` on slow connections.

## Problem

The SDK created the iframe lazily on `tryOn` and opened the handshake immediately after, so the 10s handshake window had to also cover the app bundle downloading and booting inside the iframe. On a throttled connection that exceeded 10s and errored.

## Changes

- **Preload the iframe** in the `Aiuta` constructor so the app bundle downloads and boots in the background before the first `tryOn` — the open is then instant instead of waiting (or timing out) on click.
- **Resilient handshake**: the app re-broadcasts its `HELLO` until it receives an `ACK`. With a preloaded iframe the app boots before the SDK attaches its handshake listener (on the first `tryOn`), so a single `HELLO` would be missed; now the app simply waits to be activated.
- **Bump `HANDSHAKE_TIMEOUT` to 30s** as an SDK-side safety net.
- **Guard `ensureIframe`** against concurrent calls (preload + an early `tryOn`) creating the iframe twice.

## Verification

`npm run lint`, `npm run build:app`, `npm run build:sdk` clean. Verify on a throttled connection (Fast 4G, cache off): load the host page, wait, then `tryOn` — it should open without a handshake timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)