### PR TITLE
Add HEIC support, image picker loader, and smart cross-fade backdrop

### DIFF
--- a/app/src/components/gallery/FullScreenGallery/components/ZoomableImage.module.scss
+++ b/app/src/components/gallery/FullScreenGallery/components/ZoomableImage.module.scss
@@ -20,15 +20,3 @@
   -webkit-user-select: none;
   -webkit-user-drag: none;
 }
-
-// The shared LoaderRing (same as the try-on loading screen), centered and
-// recolored white by overriding the color variable it draws with. Centered via
-// margin, not transform, because LoaderRing animates its own transform (rotation).
-.spinner {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  margin: -10px 0 0 -10px;
-  --aiuta-color-primary: var(--aiuta-color-on-dark);
-  pointer-events: none;
-}

--- a/app/src/components/gallery/FullScreenGallery/components/ZoomableImage.tsx
+++ b/app/src/components/gallery/FullScreenGallery/components/ZoomableImage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { LoaderRing } from '@/components'
+import { Loader } from '@/components/ui/Loader'
 import styles from './ZoomableImage.module.scss'
 
 // Max magnification relative to the fit-to-screen scale.
@@ -541,7 +541,7 @@ export const ZoomableImage = ({
       className={styles.container}
       onClick={tapToClose ? () => onClose() : undefined}
     >
-      {!ready && showSpinner && <LoaderRing className={styles.spinner} />}
+      {!ready && showSpinner && <Loader onDark />}
       <img
         src={src}
         alt={alt}

--- a/app/src/components/images/CrossFadeImage/CrossFadeImage.module.scss
+++ b/app/src/components/images/CrossFadeImage/CrossFadeImage.module.scss
@@ -8,6 +8,21 @@
   line-height: 0;
 }
 
+// Image + its blur backdrop fade together as one unit. Animating the layer's
+// opacity (not each child's) composites the opaque contained image over the
+// backdrop first, then fades the result — so the image never shows its own
+// backdrop through itself ("mush"); the backdrop only reads in the letterbox.
+.layer {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.layer_loaded {
+  opacity: 1;
+}
+
 .image {
   position: absolute;
   top: 0;
@@ -17,12 +32,6 @@
   height: 100%;
   object-fit: cover;
   object-position: center;
-  opacity: 0;
-  transition: opacity 0.3s ease-in-out;
-}
-
-.image_loaded {
-  opacity: 1;
 }
 
 // Smart fit: the image is contained (never cropped by height) over a blurred
@@ -41,25 +50,4 @@
   // Hides the translucent blur edges behind the container bounds
   transform: scale(1.12);
   pointer-events: none;
-  opacity: 0;
-}
-
-// An animation rather than a transition: the backdrop often mounts with the
-// loaded class already applied (the contain fit is only known after the main
-// image loads), and a transition wouldn't play in that case
-.blurBackdrop_loaded {
-  opacity: 1;
-  animation: backdrop_fade_in 0.3s ease-in-out;
-}
-
-// Applied when the backdrop mounts while the image is already on screen
-// (resize-driven fit change): no fade, it should look like it was there
-.blurBackdrop_instant {
-  animation: none;
-}
-
-@keyframes backdrop_fade_in {
-  from {
-    opacity: 0;
-  }
 }

--- a/app/src/components/images/CrossFadeImage/CrossFadeImage.tsx
+++ b/app/src/components/images/CrossFadeImage/CrossFadeImage.tsx
@@ -8,6 +8,9 @@ const MAX_WIDTH_CROP = 1 / 4
 // Side bars this thin (per side) read as an artifact rather than a frame,
 // so a barely-narrower image is covered (cropping a bit of height) instead
 const MAX_SIDE_BAR_PX = 0
+// Matches the layer's CSS opacity transition; how long the outgoing layer is
+// kept around to fade out
+const FADE_MS = 300
 
 /**
  * Picks how to fit an image of the given aspect ratio (width/height) into
@@ -16,7 +19,7 @@ const MAX_SIDE_BAR_PX = 0
  *   while the cropped fraction stays under MAX_WIDTH_CROP;
  * - a narrower image is covered (cropping some height) only when containing
  *   it would leave side bars of MAX_SIDE_BAR_PX or thinner;
- * - anything else is contained (the caller renders a blurred backdrop).
+ * - anything else is contained (a blurred backdrop fills the letterbox).
  */
 const resolveFit = (
   imageRatio: number,
@@ -33,6 +36,15 @@ const resolveFit = (
   return sideBar <= MAX_SIDE_BAR_PX ? 'cover' : 'contain'
 }
 
+/**
+ * Cross-fades between images. Each image + its blur backdrop is one composited
+ * "layer" whose opacity is animated, so the (opaque) contained image fully
+ * covers its own backdrop — no see-through mush, and the backdrop only reads in
+ * the letterbox. On a src change the new layer fades in on top while the
+ * previous one stays underneath, then the previous one is removed once the new
+ * fully covers it (no dissolve). The previous layer keeps its DOM (keyed by
+ * src) so it isn't reloaded/reflashed. Every image appears as one fading-in unit.
+ */
 export const CrossFadeImage = ({
   src,
   alt,
@@ -42,17 +54,20 @@ export const CrossFadeImage = ({
   onLoad,
   onError,
 }: CrossFadeImageProps) => {
+  // currentSrc fades in; prevSrc (if any) is the outgoing layer kept underneath
   const [currentSrc, setCurrentSrc] = useState(src)
-  const [nextSrc, setNextSrc] = useState<string | null>(null)
-  const [pendingSrc, setPendingSrc] = useState<string | null>(null)
-  const [isCurrentLoaded, setIsCurrentLoaded] = useState(false)
-  const [isNextLoaded, setIsNextLoaded] = useState(false)
-  const [isTransitioning, setIsTransitioning] = useState(false)
-  const previousSrc = useRef(src)
+  const [prevSrc, setPrevSrc] = useState<string | null>(null)
+  // The layer fades in only once BOTH its image and its backdrop are ready, so
+  // they appear together as one unit (the backdrop never pops in late).
+  const [imageReady, setImageReady] = useState(false)
+  const [backdropReady, setBackdropReady] = useState(false)
+  const currentSrcRef = useRef(src)
+  // Bumped on every src change; a decode() that resolves for a stale src is
+  // ignored (its element may already be the outgoing layer).
+  const loadToken = useRef(0)
 
-  // Smart fit inputs: the container size (kept up to date by a
-  // ResizeObserver) and the natural ratio of every image seen so far
-  // (recorded on load; reads happen after a load triggers a re-render)
+  // Smart fit inputs: the container size (kept up to date by a ResizeObserver)
+  // and the natural ratio of every image seen so far (recorded on load).
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [containerSize, setContainerSize] = useState<{ width: number; height: number } | null>(null)
   const imageRatios = useRef(new Map<string, number>())
@@ -90,6 +105,20 @@ export const CrossFadeImage = ({
     return () => observer.disconnect()
   }, [fit])
 
+  // On a src change the old src becomes the outgoing layer (kept fully visible
+  // underneath until the new layer has faded in on top), the new becomes the
+  // current layer (transparent, fades in once ready). currentSrcRef avoids a
+  // render loop without listing it as a dep.
+  useEffect(() => {
+    if (src === currentSrcRef.current) return
+    setPrevSrc(currentSrcRef.current)
+    currentSrcRef.current = src
+    loadToken.current += 1
+    setCurrentSrc(src)
+    setImageReady(false)
+    setBackdropReady(false)
+  }, [src])
+
   const recordImageRatio = (event: React.SyntheticEvent<HTMLImageElement>) => {
     const { naturalWidth, naturalHeight } = event.currentTarget
     if (naturalWidth > 0 && naturalHeight > 0) {
@@ -108,185 +137,119 @@ export const CrossFadeImage = ({
       : resolveFit(ratio, containerSize.width, containerSize.height)
   }
 
-  // Handle src changes for cross-fade
-  useEffect(() => {
-    if (src !== previousSrc.current) {
-      if (isCurrentLoaded) {
-        if (isTransitioning) {
-          // Animation in progress - always update pending to the latest src
-          setPendingSrc(src)
-        } else {
-          // Start transition to new image
-          setNextSrc(src)
-          setIsNextLoaded(false)
-          setIsTransitioning(true)
-        }
-      } else {
-        // First load or current image not loaded yet
-        setCurrentSrc(src)
+  // Mark a layer part ready only once it's decoded (ready to paint), not merely
+  // loaded: onLoad fires on download, but a separate <img> — especially the
+  // blurred backdrop — paints a frame or two later. Gating the fade on load
+  // alone reveals the contained image before its backdrop has painted, so the
+  // old image shows through the letterbox until the backdrop "arrives".
+  const markReadyWhenDecoded = useCallback(
+    (img: HTMLImageElement, setReady: (ready: boolean) => void) => {
+      const token = loadToken.current
+      const finish = () => {
+        if (token === loadToken.current) setReady(true)
       }
-      previousSrc.current = src
-    }
-  }, [src, isCurrentLoaded, isTransitioning, currentSrc, nextSrc, pendingSrc])
+      if (img.decode) img.decode().then(finish, finish)
+      else finish()
+    },
+    [],
+  )
 
   const handleCurrentLoad = useCallback(
     (event: React.SyntheticEvent<HTMLImageElement>) => {
       recordImageRatio(event)
-      setIsCurrentLoaded(true)
-      if (!isTransitioning) {
-        onLoad?.()
-      }
+      markReadyWhenDecoded(event.currentTarget, setImageReady)
+      onLoad?.()
     },
-    [onLoad, isTransitioning],
+    [onLoad, markReadyWhenDecoded],
   )
 
-  const handleNextLoad = useCallback(
+  const handleBackdropLoad = useCallback(
     (event: React.SyntheticEvent<HTMLImageElement>) => {
-      recordImageRatio(event)
-      // Force a small delay to ensure CSS transition starts
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          setIsNextLoaded(true)
-        })
-
-        // Wait for the fade-in animation to complete before switching
-        setTimeout(() => {
-          setCurrentSrc(nextSrc!)
-          setIsCurrentLoaded(true)
-          setNextSrc(null)
-          setIsNextLoaded(false)
-          setIsTransitioning(false)
-
-          // Use functional update to get current pendingSrc value
-          setPendingSrc((currentPendingSrc) => {
-            if (currentPendingSrc) {
-              // Update previousSrc to ensure we track the latest transition
-              previousSrc.current = currentPendingSrc
-              // Start next transition immediately
-              setTimeout(() => {
-                setNextSrc(currentPendingSrc)
-                setIsNextLoaded(false)
-                setIsTransitioning(true)
-              }, 0)
-              return null // Clear pendingSrc
-            } else {
-              onLoad?.()
-              return null // Keep pendingSrc as null
-            }
-          })
-        }, 300) // Match the CSS transition duration
-      })
+      markReadyWhenDecoded(event.currentTarget, setBackdropReady)
     },
-    [nextSrc, onLoad],
+    [markReadyWhenDecoded],
   )
+
+  const handleBackdropError = useCallback(() => setBackdropReady(true), [])
 
   const handleCurrentError = useCallback(() => {
-    setIsCurrentLoaded(false)
+    setImageReady(false)
     onError?.()
   }, [onError])
 
-  const handleNextError = useCallback(() => {
-    // If next image fails, try pending or cancel transition
-    if (pendingSrc) {
-      const nextPendingSrc = pendingSrc
-      setPendingSrc(null)
-      setNextSrc(nextPendingSrc)
-      setIsNextLoaded(false)
-      // Keep isTransitioning true to continue with pending
-    } else {
-      setNextSrc(null)
-      setIsNextLoaded(false)
-      setIsTransitioning(false)
-      onError?.()
-    }
-  }, [pendingSrc, onError])
-
   const containerClasses = combineClassNames(styles.crossFadeImage, className)
 
-  const currentFit = getFitForSrc(currentSrc)
-  const nextFit = nextSrc ? getFitForSrc(nextSrc) : 'cover'
+  // The backdrop only exists in smart mode; the layer is "loaded" (ready to
+  // fade in) once the image and — when present — the backdrop are both ready.
+  const needsBackdrop = fit === 'smart'
+  const currentLoaded = imageReady && (!needsBackdrop || backdropReady)
 
-  // The backdrop fades in the first time it appears for an image (together
-  // with the image's own load fade — otherwise smart fit flipping cover→
-  // contain after load would pop the dark blurred backdrop in, a visible
-  // flash on full-bleed mobile). A later re-show for the same image — a resize
-  // flipping the fit — is instant, as if it had been there all along.
-  const showCurrentBackdrop = currentFit === 'contain'
-  const seenBackdropSrcs = useRef(new Set<string>())
-  const currentBackdropMountedRef = useRef(false)
-  const animateCurrentBackdropRef = useRef(true)
-  if (showCurrentBackdrop && !currentBackdropMountedRef.current) {
-    animateCurrentBackdropRef.current = !seenBackdropSrcs.current.has(currentSrc)
-    seenBackdropSrcs.current.add(currentSrc)
-  }
+  // Once the new layer is fully shown, drop the outgoing layer (it's covered)
   useEffect(() => {
-    currentBackdropMountedRef.current = showCurrentBackdrop
-  })
+    if (!currentLoaded || !prevSrc) return
+    const timer = setTimeout(() => setPrevSrc(null), FADE_MS)
+    return () => clearTimeout(timer)
+  }, [currentLoaded, prevSrc])
 
-  const currentImageClasses = combineClassNames(
-    styles.image,
-    currentFit === 'contain' && styles.image_contain,
-    isCurrentLoaded && styles.image_loaded,
-  )
-
-  const nextImageClasses = combineClassNames(
-    styles.image,
-    nextFit === 'contain' && styles.image_contain,
-    isNextLoaded && styles.image_loaded,
-  )
+  const currentFit = getFitForSrc(currentSrc)
+  const prevFit = prevSrc ? getFitForSrc(prevSrc) : 'cover'
 
   return (
     <div className={containerClasses} ref={containerRef}>
-      {showCurrentBackdrop && (
+      {prevSrc && (
+        // Outgoing layer: stays fully opaque underneath while the new layer
+        // fades in on top, then is removed once the new one fully covers it
+        // (no dissolve). Keyed by src so React reuses the existing
+        // (already-loaded) element instead of reloading.
+        <div
+          key={prevSrc}
+          className={combineClassNames(styles.layer, styles.layer_loaded)}
+          aria-hidden="true"
+        >
+          {fit === 'smart' && (
+            <img src={prevSrc} alt="" className={styles.blurBackdrop} decoding="async" draggable={false} />
+          )}
+          <img
+            src={prevSrc}
+            alt=""
+            className={combineClassNames(styles.image, prevFit === 'contain' && styles.image_contain)}
+            decoding="async"
+            draggable={false}
+          />
+        </div>
+      )}
+
+      <div
+        key={currentSrc}
+        className={combineClassNames(styles.layer, currentLoaded && styles.layer_loaded)}
+      >
+        {/* Rendered for every smart image (not just once contain is resolved) so
+            it loads/decodes alongside the main image and fades in with the layer
+            instead of popping in late. For a cover image it sits hidden behind
+            the full-bleed image. */}
+        {fit === 'smart' && (
+          <img
+            src={currentSrc}
+            alt=""
+            aria-hidden="true"
+            className={styles.blurBackdrop}
+            decoding="async"
+            draggable={false}
+            onLoad={handleBackdropLoad}
+            onError={handleBackdropError}
+          />
+        )}
         <img
           src={currentSrc}
-          alt=""
-          aria-hidden="true"
-          className={combineClassNames(
-            styles.blurBackdrop,
-            isCurrentLoaded && styles.blurBackdrop_loaded,
-            !animateCurrentBackdropRef.current && styles.blurBackdrop_instant,
-          )}
-          decoding="async"
-          draggable={false}
-        />
-      )}
-      <img
-        src={currentSrc}
-        alt={alt}
-        className={currentImageClasses}
-        loading={loading}
-        decoding="async"
-        draggable={false}
-        onLoad={handleCurrentLoad}
-        onError={handleCurrentError}
-      />
-
-      {nextSrc && nextFit === 'contain' && (
-        <img
-          src={nextSrc}
-          alt=""
-          aria-hidden="true"
-          className={combineClassNames(
-            styles.blurBackdrop,
-            isNextLoaded && styles.blurBackdrop_loaded,
-          )}
-          decoding="async"
-          draggable={false}
-        />
-      )}
-      {nextSrc && (
-        <img
-          src={nextSrc}
           alt={alt}
-          className={nextImageClasses}
-          loading="eager"
+          className={combineClassNames(styles.image, currentFit === 'contain' && styles.image_contain)}
+          loading={loading}
           decoding="async"
           draggable={false}
-          onLoad={handleNextLoad}
-          onError={handleNextError}
+          onLoad={handleCurrentLoad}
+          onError={handleCurrentError}
         />
-      )}
+      </div>
     </div>
   )
 }

--- a/app/src/components/images/RemoteImage/RemoteImage.tsx
+++ b/app/src/components/images/RemoteImage/RemoteImage.tsx
@@ -58,6 +58,13 @@ export const RemoteImage = ({
       onError?.()
     }
 
+    // Local blobs/data URLs don't support HEAD (it errors with
+    // ERR_METHOD_NOT_SUPPORTED) and won't recover on retry — fail immediately.
+    if (urlAtFailure.startsWith('blob:') || urlAtFailure.startsWith('data:')) {
+      failNow()
+      return
+    }
+
     if (attempt >= MAX_RETRIES) {
       failNow()
       return

--- a/app/src/components/index.ts
+++ b/app/src/components/index.ts
@@ -3,6 +3,8 @@
 // General UI
 export { AppContainer } from './ui/AppContainer'
 export { Shell } from './ui/Shell'
+export { Loader } from './ui/Loader'
+export { ImagePickerLoader } from './ui/ImagePickerLoader'
 export { PageBar } from './ui/PageBar'
 export { PoweredBy } from './ui/PoweredBy'
 export { Icon } from './ui/Icon'

--- a/app/src/components/tryOn/TryOnView/TryOnView.tsx
+++ b/app/src/components/tryOn/TryOnView/TryOnView.tsx
@@ -1,9 +1,16 @@
 import React, { useState, useEffect, useCallback } from 'react'
-import { TryOnStatus, RemoteImage, Flex } from '@/components'
+import { TryOnStatus, RemoteImage, Flex, Loader } from '@/components'
 import { combineClassNames } from '@/utils'
 import { useImagePickerStrings } from '@/hooks'
+import { useAppSelector } from '@/store/store'
+import { isProcessingImageSelector } from '@/store/slices/tryOnSlice'
 import { isNewImage, isInputImage, type TryOnImage } from '@/models'
 import styles from './TryOnView.module.scss'
+
+// Delay before showing the loader, so a fast image (jpg/png) that paints almost
+// immediately doesn't flash it. Also longer than the cross-fade so a normal
+// image swap (its onLoad lands after the ~0.3s transition) never flashes it.
+const LOADER_DELAY_MS = 500
 
 interface TryOnViewProps {
   image: TryOnImage | null
@@ -23,6 +30,16 @@ export const TryOnView = ({ image, isGenerating, onChangePhoto, fill = false }: 
   // Fix backdrop-filter refresh with minimal opacity change
   const [buttonOpacity, setButtonOpacity] = useState(1)
 
+  // A picked file is being prepared (resize / HEIC decode). While it is, the
+  // previous image is hidden and a loader is shown instead.
+  const isProcessing = useAppSelector(isProcessingImageSelector)
+
+  // Whether the currently selected image has painted. Reset per image, so a new
+  // selection shows the loader (not the old image) until the new one is ready.
+  const [imageLoaded, setImageLoaded] = useState(false)
+  // The loader appears only after LOADER_DELAY_MS of still-not-ready
+  const [loaderVisible, setLoaderVisible] = useState(false)
+
   // Force backdrop-filter refresh
   const refreshBackdropFilter = () => {
     setButtonOpacity(0.99)
@@ -41,34 +58,55 @@ export const TryOnView = ({ image, isGenerating, onChangePhoto, fill = false }: 
         : null
     : null
 
-  // Refresh when image changes
+  // A new image hasn't painted yet → show the loader until it loads
   useEffect(() => {
+    setImageLoaded(false)
     if (imageUrl) {
       const timer = refreshBackdropFilter()
       return () => clearTimeout(timer)
     }
   }, [imageUrl])
 
-  // Refresh when image actually loads
+  // Refresh when image actually loads. onLoad can fire during a concurrent
+  // render (a cached/instant image in React 19), so the first refresh runs in a
+  // microtask — out of the render phase (no "setState while rendering" warning)
+  // but still this frame, before paint (no visible backdrop flicker).
   const handleImageLoad = useCallback(() => {
-    // Immediate refresh
-    refreshBackdropFilter()
-
-    // Delayed refresh to ensure image is fully rendered
-    setTimeout(() => {
+    // Defer state updates out of the render phase: onLoad can fire during a
+    // concurrent render (cached/instant image in React 19), and a synchronous
+    // setState there both warns and forces an extra re-render that flickers the
+    // image in Chrome.
+    queueMicrotask(() => {
+      setImageLoaded(true)
       refreshBackdropFilter()
-    }, 100)
+    })
 
-    // Extra delayed refresh as fallback
-    setTimeout(() => {
-      refreshBackdropFilter()
-    }, 300)
+    // Delayed refreshes to ensure the image is fully rendered
+    setTimeout(() => refreshBackdropFilter(), 100)
+    setTimeout(() => refreshBackdropFilter(), 300)
   }, [])
 
-  // If there is no image to show
-  if (!imageUrl) {
+  // Loader is wanted while preparing or until the image paints (the generation
+  // veil takes over once generation starts), but only shown after a short delay
+  const wantsLoader = (isProcessing || (!!imageUrl && !imageLoaded)) && !isGenerating
+  useEffect(() => {
+    if (!wantsLoader) {
+      setLoaderVisible(false)
+      return
+    }
+    const timer = setTimeout(() => setLoaderVisible(true), LOADER_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [wantsLoader])
+
+  // Nothing to show and nothing being prepared
+  if (!imageUrl && !isProcessing) {
     return null
   }
+
+  // Keep the current image (and its cross-fade) until the loader actually
+  // appears — so a fast decode just cross-fades old → new, and only a slow
+  // decode unmounts the old image right when the loader shows.
+  const showImage = !!imageUrl && !(isProcessing && loaderVisible)
 
   return (
     <Flex
@@ -81,18 +119,22 @@ export const TryOnView = ({ image, isGenerating, onChangePhoto, fill = false }: 
         isGenerating && (fill ? styles.loadingGradient : styles.animation),
       )}
     >
-      <RemoteImage
-        src={imageUrl}
-        alt="Try-on image"
-        shape={fill ? 'M' : 'L'}
-        fit="smart"
-        onLoad={handleImageLoad}
-      />
+      {showImage && (
+        <RemoteImage
+          src={imageUrl}
+          alt="Try-on image"
+          shape={fill ? 'M' : 'L'}
+          fit="smart"
+          onLoad={handleImageLoad}
+        />
+      )}
+
+      {loaderVisible && <Loader />}
 
       {/* On desktop (fill) the page renders the status below the image */}
       {isGenerating && !fill && <TryOnStatus className={styles.processingStatus} />}
 
-      {!isGenerating && onChangePhoto && (
+      {!isGenerating && !loaderVisible && onChangePhoto && (
         <button
           className={`aiuta-button-s ${styles.changePhotoButton}`}
           style={{ opacity: buttonOpacity }}

--- a/app/src/components/ui/ImagePickerLoader/ImagePickerLoader.tsx
+++ b/app/src/components/ui/ImagePickerLoader/ImagePickerLoader.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useAppSelector } from '@/store/store'
+import { isProcessingImageSelector } from '@/store/slices/tryOnSlice'
+import { Loader } from '@/components/ui/Loader'
+
+// Delay before showing the loader, so a fast image doesn't flash it (matches
+// TryOnView)
+const LOADER_DELAY_MS = 500
+
+/**
+ * Loader shown while a picked file is being prepared (resize / HEIC decode,
+ * which lazy-loads a wasm decoder and can take a moment) on pages that don't
+ * have their own preview-area loader. The try-on preview (`/tryon`) shows its
+ * own in-area loader, so skip it there.
+ */
+export const ImagePickerLoader = () => {
+  const isProcessing = useAppSelector(isProcessingImageSelector)
+  const { pathname } = useLocation()
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!isProcessing) {
+      setVisible(false)
+      return
+    }
+    const timer = setTimeout(() => setVisible(true), LOADER_DELAY_MS)
+    return () => clearTimeout(timer)
+  }, [isProcessing])
+
+  if (!visible || pathname === '/tryon') return null
+
+  return <Loader />
+}

--- a/app/src/components/ui/ImagePickerLoader/index.ts
+++ b/app/src/components/ui/ImagePickerLoader/index.ts
@@ -1,0 +1,1 @@
+export { ImagePickerLoader } from './ImagePickerLoader'

--- a/app/src/components/ui/Loader/Loader.module.scss
+++ b/app/src/components/ui/Loader/Loader.module.scss
@@ -1,0 +1,14 @@
+.loader {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+// LoaderRing draws with --aiuta-color-primary; recolor it for dark backdrops
+.loader_onDark {
+  --aiuta-color-primary: var(--aiuta-color-on-dark);
+}

--- a/app/src/components/ui/Loader/Loader.tsx
+++ b/app/src/components/ui/Loader/Loader.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { combineClassNames } from '@/utils'
+import { LoaderRing } from '@/components/indicators/LoaderRing'
+import styles from './Loader.module.scss'
+
+interface LoaderProps {
+  /** White ring for dark backgrounds (default draws in the primary color) */
+  onDark?: boolean
+  className?: string
+}
+
+/**
+ * Centered LoaderRing overlay that fills its positioned parent. Shared by the
+ * image picker (processing), the try-on preview, and the fullscreen viewer.
+ */
+export const Loader = ({ onDark, className }: LoaderProps) => (
+  <div className={combineClassNames(styles.loader, onDark && styles.loader_onDark, className)}>
+    <LoaderRing />
+  </div>
+)

--- a/app/src/components/ui/Loader/index.ts
+++ b/app/src/components/ui/Loader/index.ts
@@ -1,0 +1,1 @@
+export { Loader } from './Loader'

--- a/app/src/hooks/picker/useQrUpload.ts
+++ b/app/src/hooks/picker/useQrUpload.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useParams, useLocation } from 'react-router-dom'
 import { useAppDispatch } from '@/store/store'
 import { errorSnackbarSlice } from '@/store/slices/errorSnackbarSlice'
+import { tryOnSlice } from '@/store/slices/tryOnSlice'
 import { QrApiService, type QrEndpointData } from '@/utils/api/qrApiService'
 import { TryOnApiService } from '@/utils/api/tryOnApiService'
 import { resizeAndConvertImage } from '@/utils'
@@ -60,22 +61,35 @@ export const useQrUpload = () => {
     }
   }, [])
 
-  // Select file for upload
-  const selectFile = useCallback((file: File) => {
-    // Cleanup previous URL
-    if (cleanupUrlRef.current) {
-      URL.revokeObjectURL(cleanupUrlRef.current)
-    }
+  // Select file for upload. Process it up front (resize, convert, fix EXIF, and
+  // decode HEIC → JPEG) so the preview renders in every browser, not just Safari,
+  // and so the upload reuses the already-processed file. Flag processing so the
+  // page can show a loader (HEIC decode can take a moment).
+  const selectFile = useCallback(
+    async (file: File) => {
+      dispatch(tryOnSlice.actions.setIsProcessingImage(true))
+      try {
+        const processedFile = await resizeAndConvertImage(file)
 
-    const objectUrl = URL.createObjectURL(file)
-    cleanupUrlRef.current = objectUrl
+        // Cleanup previous URL
+        if (cleanupUrlRef.current) {
+          URL.revokeObjectURL(cleanupUrlRef.current)
+        }
 
-    setUploadState((prev) => ({
-      ...prev,
-      selectedFile: { file, url: objectUrl },
-      uploadedUrl: null,
-    }))
-  }, [])
+        const objectUrl = URL.createObjectURL(processedFile)
+        cleanupUrlRef.current = objectUrl
+
+        setUploadState((prev) => ({
+          ...prev,
+          selectedFile: { file: processedFile, url: objectUrl },
+          uploadedUrl: null,
+        }))
+      } finally {
+        dispatch(tryOnSlice.actions.setIsProcessingImage(false))
+      }
+    },
+    [dispatch],
+  )
 
   // Handle upload errors
   const handleUploadError = useCallback(

--- a/app/src/hooks/results/useImageTone.ts
+++ b/app/src/hooks/results/useImageTone.ts
@@ -46,7 +46,9 @@ const computeTone = (url: string): Promise<ImageToneInfo> =>
         const canvas = document.createElement('canvas')
         canvas.width = SAMPLE_WIDTH
         canvas.height = SAMPLE_HEIGHT
-        const ctx = canvas.getContext('2d')
+        // willReadFrequently: this canvas exists only to getImageData (read
+        // back pixels), so hint the browser to keep it on the CPU
+        const ctx = canvas.getContext('2d', { willReadFrequently: true })
         if (!ctx) {
           resolve(DARK_FALLBACK)
           return

--- a/app/src/hooks/tryOn/useTryOnImage.ts
+++ b/app/src/hooks/tryOn/useTryOnImage.ts
@@ -9,16 +9,23 @@ export const useTryOnImage = () => {
 
   const selectImageToTryOn = useCallback(
     async (file: File): Promise<NewImage> => {
-      const processedFile = await resizeAndConvertImage(file)
+      // Preparing can take a while (resize, and especially HEIC decode which
+      // lazy-loads a wasm decoder) — flag it so the UI can show a loader.
+      dispatch(tryOnSlice.actions.setIsProcessingImage(true))
+      try {
+        const processedFile = await resizeAndConvertImage(file)
 
-      const newImage: NewImage = {
-        file: processedFile,
-        localUrl: URL.createObjectURL(processedFile),
+        const newImage: NewImage = {
+          file: processedFile,
+          localUrl: URL.createObjectURL(processedFile),
+        }
+
+        dispatch(tryOnSlice.actions.setSelectedImage(newImage))
+
+        return newImage
+      } finally {
+        dispatch(tryOnSlice.actions.setIsProcessingImage(false))
       }
-
-      dispatch(tryOnSlice.actions.setSelectedImage(newImage))
-
-      return newImage
     },
     [dispatch],
   )

--- a/app/src/routing/MainApp.tsx
+++ b/app/src/routing/MainApp.tsx
@@ -16,6 +16,7 @@ import {
   AppContainer,
   ConfigError,
   Shell,
+  ImagePickerLoader,
 } from '@/components'
 import {
   useUrlParams,
@@ -130,6 +131,9 @@ function AppContent() {
             <Route path="/generations" element={<GenerationsHistoryPage />} />
             <Route path="/uploads" element={<UploadsHistoryPage />} />
           </Routes>
+
+          {/* Covers the picker while a picked file is being prepared */}
+          <ImagePickerLoader />
         </AppContainer>
 
         <FullScreenGallery />

--- a/app/src/routing/QrUpload.tsx
+++ b/app/src/routing/QrUpload.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { AppContainer, Shell } from '@/components'
+import { AppContainer, Shell, ImagePickerLoader } from '@/components'
 import { useUrlParams, useCustomCssUrl, useStandaloneApp } from '@/hooks'
 import QrUploadPage from '@/pages/3-QrUpload'
 
@@ -25,6 +25,8 @@ export const QrUpload = () => {
       <AppContainer fullscreen>
         {/* PoweredBy is rendered inside the page — it depends on the upload state */}
         <QrUploadPage />
+        {/* Covers the page while a picked file is being prepared (HEIC decode) */}
+        <ImagePickerLoader />
       </AppContainer>
     </Shell>
   )

--- a/app/src/store/slices/tryOnSlice/index.ts
+++ b/app/src/store/slices/tryOnSlice/index.ts
@@ -1,6 +1,7 @@
 export { tryOnSlice, type TryOnState, type GenerationStage } from './tryOnSlice'
 export {
   isGeneratingSelector,
+  isProcessingImageSelector,
   selectedImageSelector,
   generationStageSelector,
   operationIdSelector,

--- a/app/src/store/slices/tryOnSlice/selectors.ts
+++ b/app/src/store/slices/tryOnSlice/selectors.ts
@@ -1,6 +1,7 @@
 import { RootState } from '@/store/store'
 
 export const isGeneratingSelector = (state: RootState) => state.tryOn.isGenerating
+export const isProcessingImageSelector = (state: RootState) => state.tryOn.isProcessingImage
 export const selectedImageSelector = (state: RootState) => state.tryOn.selectedImage
 export const generationStageSelector = (state: RootState) => state.tryOn.generationStage
 export const operationIdSelector = (state: RootState) => state.tryOn.operationId

--- a/app/src/store/slices/tryOnSlice/tryOnSlice.ts
+++ b/app/src/store/slices/tryOnSlice/tryOnSlice.ts
@@ -7,6 +7,8 @@ export type GenerationStage = 'idle' | 'uploading' | 'scanning' | 'generating'
 
 export interface TryOnState {
   isGenerating: boolean
+  // A picked file is being prepared (resize / HEIC decode) before it can show
+  isProcessingImage: boolean
   selectedImage: TryOnImage | null
   generationStage: GenerationStage
   operationId: string | null
@@ -18,6 +20,7 @@ export interface TryOnState {
 
 const initialState: TryOnState = {
   isGenerating: false,
+  isProcessingImage: false,
   selectedImage: null,
   generationStage: 'idle',
   operationId: null,
@@ -35,6 +38,10 @@ export const tryOnSlice = createSlice({
       if (!action.payload) {
         state.generationStage = 'idle'
       }
+    },
+
+    setIsProcessingImage: (state, action: PayloadAction<boolean>) => {
+      state.isProcessingImage = action.payload
     },
 
     setSelectedImage: (state, action: PayloadAction<TryOnImage | null>) => {

--- a/app/src/styles/shapes.css
+++ b/app/src/styles/shapes.css
@@ -25,22 +25,32 @@
   border-radius: 8px;
 }
 
+/*
+ * Image shapes. The neutral fill is the image-area placeholder: it shows only
+ * while there's no image yet (loading) — otherwise the image and its blur
+ * backdrop cover it.
+ */
+
 /* Image Large Shape */
 .aiuta-image-l {
   border-radius: 24px;
+  background-color: var(--aiuta-color-neutral);
 }
 
 /* Image Medium Shape */
 .aiuta-image-m {
   border-radius: 16px;
+  background-color: var(--aiuta-color-neutral);
 }
 
 /* Image Small Shape */
 .aiuta-image-s {
   border-radius: 8px;
+  background-color: var(--aiuta-color-neutral);
 }
 
 /* Image Extra Small Shape */
 .aiuta-image-xs {
   border-radius: 4px;
+  background-color: var(--aiuta-color-neutral);
 }

--- a/app/src/utils/helpers/resizeAndConvertImage.ts
+++ b/app/src/utils/helpers/resizeAndConvertImage.ts
@@ -3,6 +3,8 @@
  *
  * Resizes and converts images while preserving quality.
  * Сorrects EXIF orientation by drawing through canvas.
+ * HEIC/HEIF (iPhone photos) are decoded to JPEG first, since browsers other
+ * than Safari can't render them in a canvas/<img>.
  */
 
 export type ProcessOptions = {
@@ -30,8 +32,28 @@ export async function resizeAndConvertImage(file: File, opts: ProcessOptions = {
   const quality = opts.quality ?? 0.92
   const maxSide = opts.maxSide ?? 1500
 
+  // HEIC/HEIF output is re-encoded to JPEG by the canvas anyway, so give it a
+  // .jpg name to keep downstream consistent.
+  const heic = isHeic(file)
+  const outputName = heic ? file.name.replace(/\.(heic|heif)$/i, '.jpg') : file.name
+
   try {
-    const img = await createImageElement(file)
+    // Try the browser's native decode first — Safari handles HEIC, so it never
+    // needs the heavy decoder. Only when the native decode fails on a HEIC
+    // (e.g. Chrome) do we lazy-load heic-to.
+    let img: HTMLImageElement
+    try {
+      img = await createImageElement(file)
+    } catch (nativeError) {
+      if (!heic) throw nativeError
+      try {
+        img = await createImageElement(await convertHeicToJpeg(file, quality))
+      } catch (decodeError) {
+        console.warn('[aiuta] HEIC → JPEG conversion failed:', decodeError)
+        throw decodeError
+      }
+    }
+
     const targetDimensions = calculateTargetDimensions(img, maxSide)
 
     const drawParams: CanvasDrawParams = {
@@ -44,7 +66,7 @@ export async function resizeAndConvertImage(file: File, opts: ProcessOptions = {
     const blob = await processOnCanvas(img, drawParams, outputMime, quality)
 
     // Create File from processed Blob
-    return new File([blob], file.name, {
+    return new File([blob], outputName, {
       type: blob.type || outputMime,
       lastModified: file.lastModified,
     })
@@ -52,6 +74,29 @@ export async function resizeAndConvertImage(file: File, opts: ProcessOptions = {
     // Fallback to original file silently (no logger needed for this helper)
     return file
   }
+}
+
+/* ===================== HEIC ===================== */
+
+/**
+ * Detect HEIC/HEIF. iOS sometimes hands over an empty MIME type, so fall back
+ * to the file extension.
+ */
+function isHeic(file: File): boolean {
+  const type = file.type.toLowerCase()
+  if (type === 'image/heic' || type === 'image/heif') return true
+  return /\.(heic|heif)$/i.test(file.name)
+}
+
+/**
+ * Decode a HEIC/HEIF blob to a JPEG blob. heic-to wraps an up-to-date
+ * libheif-js (handles modern iPhone photos that heic2any's older build
+ * rejected with "ERR_LIBHEIF format not supported"). Loaded lazily — only when
+ * a HEIC is actually picked — to keep the wasm decoder out of the main bundle.
+ */
+async function convertHeicToJpeg(file: Blob, quality: number): Promise<Blob> {
+  const { heicTo } = await import('heic-to')
+  return heicTo({ blob: file, type: 'image/jpeg', quality })
 }
 
 /* ===================== DIMENSIONS ===================== */

--- a/demo/src/hooks/useImageGradient.ts
+++ b/demo/src/hooks/useImageGradient.ts
@@ -70,7 +70,9 @@ const getCardLook = (url: string): Promise<CardLook> =>
     img.onload = () => {
       try {
         const canvas = document.createElement('canvas')
-        const ctx = canvas.getContext('2d')
+        // willReadFrequently: this canvas is sampled via getImageData, so keep
+        // it on the CPU for fast readback
+        const ctx = canvas.getContext('2d', { willReadFrequently: true })
         if (!ctx) {
           reject(new Error('Canvas not supported'))
           return

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bowser": "^2.12.1",
         "dayjs": "^1.11.18",
         "formidable": "^3.5.4",
+        "heic-to": "^1.5.2",
         "qr-code-styling": "^1.9.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3245,6 +3246,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/heic-to": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+      "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
+      "license": "LGPL-3.0"
     },
     "node_modules/html-minifier-terser": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "bowser": "^2.12.1",
     "dayjs": "^1.11.18",
     "formidable": "^3.5.4",
+    "heic-to": "^1.5.2",
     "qr-code-styling": "^1.9.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
## Summary

Display HEIC/HEIF photos in non-Safari browsers and smooth out the picker/preview image flow.

- **HEIC decode** — try the browser's native decode first (Safari handles HEIC natively), and only on failure lazy-load `heic-to` (an up-to-date libheif-js) to convert to JPEG. Keeps the wasm decoder out of the main bundle and off Safari. Replaces `heic2any`, which rejected modern iPhone photos with `ERR_LIBHEIF format not supported`.
- **Image picker loader** — new `Loader` + `ImagePickerLoader` components show a delayed spinner while a picked file is being prepared (resize / HEIC decode), so the slow wasm path no longer looks frozen. Backed by a new `isProcessingImage` flag in `tryOnSlice`.
- **TryOnView** — keep the current image (and its cross-fade) until the loader actually appears: a fast decode just cross-fades, only a slow decode swaps in the loader. Defers `onLoad` state updates out of the render phase to avoid a React 19 setState-while-rendering warning.
- **CrossFadeImage** — composite each image with its blur backdrop as one layer and fade the layer as a unit (no see-through mush); reveal it only once both the image **and** its backdrop are *decoded* (not merely loaded), so the backdrop never pops in after the image.
- **RemoteImage** — fail `blob:`/`data:` URLs immediately on error (they don't support the HEAD retry probe).
- **shapes.css** — neutral image-area placeholder behind loading images.
- `willReadFrequently` on the tone/gradient canvas readbacks (app + demo).

## Test plan

- `npm run lint` ✅ (eslint + tsc)
- `npm run build:app` ✅ (`heic-to` lands in its own lazy chunk)
- Manual: pick a HEIC photo in Chrome → spinner shows during decode → image displays; cross-fade between contain images reveals image + blur backdrop together (no letterbox flash of the previous image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)