### PR TITLE
Demo tabs, model-category preselection, and results disclaimer rework

### DIFF
--- a/app/src/components/results/Disclaimer/Disclaimer.module.scss
+++ b/app/src/components/results/Disclaimer/Disclaimer.module.scss
@@ -2,75 +2,56 @@
 .disclaimer {
   display: flex;
   align-items: center;
-  padding: 4px 12px;
-  gap: 4px;
-  color: var(--aiuta-color-secondary);
+  justify-content: center;
   cursor: pointer;
 }
 
-.icon {
-  flex-shrink: 0;
-}
-
 .text {
-  flex: 1;
+  font-size: 11px;
+  line-height: normal;
+  letter-spacing: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
 }
 
-// A 20px strip pinned to the bottom edge of the image. The fill is tinted
-// inline with the photo's average bottom color (see Disclaimer.tsx); the
-// grey here is only the fallback for a missing tint.
-.disclaimer_overlay {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 2;
-  height: 20px;
+// Desktop (Figma 12340-33737): a plain footnote below the action tiles. Its
+// 30px box spans the gap from the tiles to the widget bottom; the text sits at
+// the bottom of it, ~1px off the edge.
+.disclaimer_plain {
+  height: 30px;
+  align-items: flex-end;
+  padding: 0 16px 1px;
+
+  .text {
+    color: color-mix(in srgb, var(--aiuta-color-secondary) 60%, transparent);
+  }
+}
+
+// Mobile: a strip flush under the photo. Its background is the photo's stretched
+// bottom row plus a tint, both set inline (see Disclaimer.tsx); the grey here is
+// only the fallback when the row image is unavailable (CORS/decode).
+.disclaimer_strip {
+  height: 18px;
   padding: 0 16px;
-  gap: 0;
-  justify-content: center;
   background-color: rgba(138, 139, 141, 0.64);
-  backdrop-filter: blur(2px);
-  // Round the strip's own bottom corners to match the image container:
-  // browsers are unreliable at clipping backdrop-filter by an ancestor's
-  // border-radius, which smudged the corners
-  border-radius: 0 0 16px 16px;
-  // The strip mounts only once the image tone is known (see ResultsDesktop),
-  // already in its final colors, and just fades in — a mount animation can't
-  // cross-fade from the wrong variant the way a transition would
+  // Mounts only once the tone is known (see ResultsMobile), already in its
+  // final colors, and just fades in.
   animation: disclaimer_fade_in 0.3s ease-in-out;
 
   .text {
-    flex: 0 1 auto;
-    font-size: 11px;
-    line-height: normal;
-    letter-spacing: 0;
     color: color-mix(in srgb, var(--aiuta-color-on-dark) 70%, transparent);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-align: center;
   }
+}
 
-  // Mobile: the image is full-bleed and square, so the strip is too
-  @media (max-width: 992px) {
-    border-radius: 0;
-  }
+// Light photo bottom: dark text (Figma 12764-35836).
+.disclaimer_stripLight .text {
+  color: color-mix(in srgb, var(--aiuta-color-on-light) 30%, transparent);
 }
 
 @keyframes disclaimer_fade_in {
   from {
     opacity: 0;
-  }
-}
-
-// Over a light image bottom (Figma 12764-35836): dark text. The fill comes
-// inline from the photo's average bottom color (see Disclaimer.tsx); this
-// transparent fallback covers a missing tint.
-.disclaimer_overlayLight {
-  background-color: rgba(138, 139, 141, 0);
-
-  .text {
-    color: color-mix(in srgb, var(--aiuta-color-on-light) 30%, transparent);
   }
 }

--- a/app/src/components/results/Disclaimer/Disclaimer.tsx
+++ b/app/src/components/results/Disclaimer/Disclaimer.tsx
@@ -1,49 +1,62 @@
 import React from 'react'
-import { Icon } from '@/components'
 import { combineClassNames } from '@/utils'
 import { useDisclaimerStrings, useDisclaimer } from '@/hooks'
 import { DisclaimerProps } from './types'
-import { icons } from './icons'
 import styles from './Disclaimer.module.scss'
 
 export const Disclaimer = ({
   className,
-  overlay = false,
+  variant = 'plain',
   tone = 'dark',
   tint = null,
+  stripUrl = null,
 }: DisclaimerProps) => {
   const { fitDisclaimerTitle } = useDisclaimerStrings()
   const { showDisclaimer } = useDisclaimer()
 
-  // Both variants tint their fill with the photo's bottom color, shifted
-  // away from the text color (darkened under white text, lightened under
-  // dark) — a tint at the photo's own brightness would drown the text.
-  // 0.35 is enough for the worst case, a mid-grey photo bottom.
+  const isStrip = variant === 'strip'
+  const isLight = isStrip && tone === 'light'
+
+  // The strip tints its fill with the photo's bottom color, shifted away from
+  // the text color (darkened under white text, lightened under dark) — a tint at
+  // the photo's own brightness would drown the text. 0.35 covers the worst case,
+  // a mid-grey photo bottom.
   const TINT_SHIFT = 0.35
-  const isLight = overlay && tone === 'light'
+  // Opacity of the tint layer over the stretched photo row — kept light so the
+  // strip reads as a continuation of the photo, just enough for legible text.
+  const TINT_ALPHA = 0.4
   const shiftChannel = (value: number) =>
     Math.round(isLight ? value + (255 - value) * TINT_SHIFT : value * (1 - TINT_SHIFT))
-  const tintStyle =
-    overlay && tint
-      ? {
-          backgroundColor: `rgba(${shiftChannel(tint[0])}, ${shiftChannel(tint[1])}, ${shiftChannel(tint[2])}, 0.64)`,
-        }
+
+  let stripStyle: React.CSSProperties | undefined
+  if (isStrip) {
+    const tintRgba = tint
+      ? `rgba(${shiftChannel(tint[0])}, ${shiftChannel(tint[1])}, ${shiftChannel(tint[2])}, ${TINT_ALPHA})`
+      : null
+    // The stretched bottom row sits under a flat tint layer (a same-stop
+    // gradient); the .scss grey fallback shows only when neither is available.
+    const layers = [
+      tintRgba ? `linear-gradient(${tintRgba}, ${tintRgba})` : null,
+      stripUrl ? `url("${stripUrl}")` : null,
+    ].filter(Boolean)
+    stripStyle = layers.length
+      ? { backgroundImage: layers.join(', '), backgroundSize: '100% 100%', backgroundRepeat: 'no-repeat' }
       : undefined
+  }
 
   return (
     <div
       className={combineClassNames(
         styles.disclaimer,
-        overlay && styles.disclaimer_overlay,
-        isLight && styles.disclaimer_overlayLight,
+        isStrip ? styles.disclaimer_strip : styles.disclaimer_plain,
+        isLight && styles.disclaimer_stripLight,
         className,
       )}
-      style={tintStyle}
+      style={stripStyle}
       onClick={showDisclaimer}
       role="button"
       tabIndex={0}
     >
-      {!overlay && <Icon icon={icons.info} size={13} className={styles.icon} />}
       <span className={combineClassNames('aiuta-label-footnote', styles.text)}>
         {fitDisclaimerTitle}
       </span>

--- a/app/src/components/results/Disclaimer/icons.ts
+++ b/app/src/components/results/Disclaimer/icons.ts
@@ -1,7 +1,0 @@
-/**
- * SVG icons used in Disclaimer component
- */
-
-export const icons = {
-  info: '<svg width="13" height="14" viewBox="0 0 13 14" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0_12026_15677)"><path d="M6.50016 12.4167C9.49171 12.4167 11.9168 9.99158 11.9168 7.00004C11.9168 4.0085 9.49171 1.58337 6.50016 1.58337C3.50862 1.58337 1.0835 4.0085 1.0835 7.00004C1.0835 9.99158 3.50862 12.4167 6.50016 12.4167Z" stroke="#9F9F9F" stroke-width="1.08333" stroke-linecap="round" stroke-linejoin="round"/><path d="M6.5 4.83337V7.00004" stroke="#9F9F9F" stroke-width="1.08333" stroke-linecap="round" stroke-linejoin="round"/><path d="M6.5 9.16663H6.50542" stroke="#9F9F9F" stroke-width="1.08333" stroke-linecap="round" stroke-linejoin="round"/></g><defs><clipPath id="clip0_12026_15677"><rect width="13" height="13" fill="white" transform="translate(0 0.5)"/></clipPath></defs></svg>',
-} as const

--- a/app/src/components/results/Disclaimer/types.ts
+++ b/app/src/components/results/Disclaimer/types.ts
@@ -2,18 +2,25 @@ export interface DisclaimerProps {
   /** Additional CSS class name for the container */
   className?: string
   /**
-   * Render as a translucent strip laid over the bottom edge of the image
-   * (desktop results, Figma) instead of the inline icon + text row
+   * - `plain`: a centered footnote at the bottom of the screen, below the
+   *   action tiles (desktop, Figma 12340-33737).
+   * - `strip`: a full-width strip flush under the photo (mobile), its
+   *   background the photo's stretched bottom row, tinted for legibility.
    */
-  overlay?: boolean
+  variant?: 'plain' | 'strip'
   /**
-   * Tone of the image area under the overlay strip: a light bottom gets the
-   * light strip with dark text (Figma 12764-35836). Defaults to dark.
+   * Tone of the photo bottom for the `strip` variant: a light row gets dark
+   * text. Defaults to dark.
    */
   tone?: 'dark' | 'light'
   /**
-   * Average color of the image bottom; the light variant tints its fill
-   * with it so the strip blends into the photo
+   * Average color of the photo's bottom row; the `strip` variant tints its
+   * fill with it so the text stays legible over the stretched row.
    */
   tint?: [number, number, number] | null
+  /**
+   * The photo's bottom 1px row as a data URL; stretched behind the `strip`
+   * variant so it reads as a continuation of the photo.
+   */
+  stripUrl?: string | null
 }

--- a/app/src/components/results/ResultActions/ResultActions.module.scss
+++ b/app/src/components/results/ResultActions/ResultActions.module.scss
@@ -1,11 +1,11 @@
-// Figma: three action tiles in a row, 8px gaps, 8px side insets,
-// 10px above the widget bottom
+// Figma: three action tiles in a row, 8px gaps, 8px side insets. The gap below
+// (to the widget bottom) is the disclaimer's 30px box, so no margin here.
 .resultActions {
   display: flex;
   gap: 8px;
   align-items: center;
   width: calc(100% - 16px);
-  margin: 0 auto 10px;
+  margin: 0 auto;
 }
 
 .actionTile {

--- a/app/src/components/tryOn/TryOnView/TryOnView.module.scss
+++ b/app/src/components/tryOn/TryOnView/TryOnView.module.scss
@@ -115,9 +115,10 @@
 }
 
 // Desktop picker preview fills the available area edge-to-edge
-// (Figma: 404x600 with 8px side insets, 8px below the navbar)
+// (Figma: 8px side insets, 8px below the navbar, 12px gap to the action row —
+// matching the results screen so the image keeps its size across the flow)
 .fillContainer {
-  padding: 8px 8px 16px;
+  padding: 8px 8px 12px;
 }
 
 // Edge-to-edge sizing comes from Flex's `fill` prop; this class only carries

--- a/app/src/hooks/app/useRpcInitialization.ts
+++ b/app/src/hooks/app/useRpcInitialization.ts
@@ -63,7 +63,11 @@ export const useRpcInitialization = () => {
         const rpc = new AiutaAppRpc({
           context: { appVersion: __APP_VERSION__ },
           handlers: {
-            tryOn: async (productIds: string | string[], mode?: AiutaMode) => {
+            tryOn: async (
+              productIds: string | string[],
+              mode?: AiutaMode,
+              options?: { gender?: string },
+            ) => {
               try {
                 // Support both single and multi-item try-on (backward compatibility)
                 const productIdsArray = Array.isArray(productIds) ? productIds : [productIds]
@@ -71,6 +75,11 @@ export const useRpcInitialization = () => {
                 // Older SDKs omit the mode; unknown values degrade to 'general'.
                 // Dispatch before showApp() so the initial-route decision sees it.
                 dispatch(tryOnSlice.actions.setMode(mode === 'shoes' ? 'shoes' : 'general'))
+
+                // Product gender → default predefined-model category for this
+                // try-on. Reset to null when absent so it doesn't leak into a
+                // later request that carried no gender.
+                dispatch(tryOnSlice.actions.setPreferredCategoryId(options?.gender ?? null))
 
                 // Show app when tryOn is called
                 showApp()

--- a/app/src/hooks/models/usePredefinedModelsSelection.ts
+++ b/app/src/hooks/models/usePredefinedModelsSelection.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAppDispatch, useAppSelector } from '@/store/store'
 import { predefinedModelsSlice } from '@/store/slices/predefinedModelsSlice'
 import { uploadsSlice } from '@/store/slices/uploadsSlice'
-import { tryOnModeSelector } from '@/store/slices/tryOnSlice'
+import { tryOnModeSelector, tryOnPreferredCategoryIdSelector } from '@/store/slices/tryOnSlice'
 import { usePredefinedModels } from './usePredefinedModels'
 import { usePredefinedModelsAnalytics } from './usePredefinedModelsAnalytics'
 import { useTryOnGeneration } from '@/hooks/tryOn/useTryOnGeneration'
@@ -29,6 +29,10 @@ export const usePredefinedModelsSelection = () => {
   const predefinedConfig = rpc.config.features?.imagePicker?.predefinedModels?.data
   const preferredCategoryId = predefinedConfig?.preferredCategoryId
   const preferredCategoryOrder = predefinedConfig?.preferredCategoryOrder
+
+  // Per-try-on override from the product gender (set via tryOn options), wins
+  // over the configured preferredCategoryId.
+  const tryOnPreferredCategoryId = useAppSelector(tryOnPreferredCategoryIdSelector)
 
   // General mode shows only full-height models in the classic picker — the
   // bird/side-view models are shoe angles, surfaced only by the shoes grouped
@@ -71,23 +75,21 @@ export const usePredefinedModelsSelection = () => {
   // The user's explicit in-session pick (null until they tap a category tab).
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null)
 
-  // Default when the user hasn't picked this session. preferredCategoryId from
-  // config wins; only when it's absent do we fall back to the saved selection;
-  // then the first available. Recomputed when categories/config arrive, so a
-  // late RPC config still applies (the choice isn't frozen on first render).
+  // Default when the user hasn't picked this session. Priority: per-try-on
+  // gender override → configured preferredCategoryId → saved selection → first.
+  // Recomputed when categories/config arrive, so a late RPC config still
+  // applies (the choice isn't frozen on first render).
   const defaultCategoryId = useMemo(() => {
     if (categories.length === 0) return null
 
-    // Config-preferred takes priority; saved value is the fallback only when no
-    // preferredCategoryId is configured.
-    const candidate = preferredCategoryId || getSavedCategoryId()
+    const candidate = tryOnPreferredCategoryId || preferredCategoryId || getSavedCategoryId()
     if (candidate) {
       const found = categories.find((cat) => cat.category === candidate)
       if (found) return found.category
     }
 
     return categories[0].category
-  }, [categories, preferredCategoryId, getSavedCategoryId])
+  }, [categories, tryOnPreferredCategoryId, preferredCategoryId, getSavedCategoryId])
 
   // Category actually shown: the explicit pick wins, otherwise the default. The
   // default is NOT persisted — only an explicit change is (see

--- a/app/src/hooks/models/usePredefinedModelsSelection.ts
+++ b/app/src/hooks/models/usePredefinedModelsSelection.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch, useAppSelector } from '@/store/store'
 import { predefinedModelsSlice } from '@/store/slices/predefinedModelsSlice'
@@ -25,25 +25,39 @@ export const usePredefinedModelsSelection = () => {
   const { startTryOn } = useTryOnGeneration()
   const { trackCategoryChange, trackModelSelected } = usePredefinedModelsAnalytics()
 
+  // Predefined-models config (preferred default category + tab order)
+  const predefinedConfig = rpc.config.features?.imagePicker?.predefinedModels?.data
+  const preferredCategoryId = predefinedConfig?.preferredCategoryId
+  const preferredCategoryOrder = predefinedConfig?.preferredCategoryOrder
+
   // General mode shows only full-height models in the classic picker — the
   // bird/side-view models are shoe angles, surfaced only by the shoes grouped
   // picker. Untagged (legacy) models are treated as full-height. Shoes mode
   // keeps every view and groups them in the UI.
   const categories = useMemo(() => {
-    if (mode === 'shoes') return allCategories
-    return allCategories
-      .map((category) => ({
-        ...category,
-        models: category.models.filter(
-          (model) => !model.tags?.view || model.tags.view === 'full-height',
-        ),
-      }))
-      .filter((category) => category.models.length > 0)
-  }, [allCategories, mode])
+    const filtered =
+      mode === 'shoes'
+        ? allCategories
+        : allCategories
+            .map((category) => ({
+              ...category,
+              models: category.models.filter(
+                (model) => !model.tags?.view || model.tags.view === 'full-height',
+              ),
+            }))
+            .filter((category) => category.models.length > 0)
 
-  // Get preferred category from config
-  const preferredCategoryId =
-    rpc.config.features?.imagePicker?.predefinedModels?.data?.preferredCategoryId
+    // Apply the configured tab order; unlisted categories keep their original
+    // order, after the listed ones (Array.prototype.sort is stable).
+    if (preferredCategoryOrder?.length) {
+      const rank = (id: string) => {
+        const index = preferredCategoryOrder.indexOf(id)
+        return index === -1 ? Number.MAX_SAFE_INTEGER : index
+      }
+      return [...filtered].sort((a, b) => rank(a.category) - rank(b.category))
+    }
+    return filtered
+  }, [allCategories, mode, preferredCategoryOrder])
 
   // Get saved category from sessionStorage
   const getSavedCategoryId = useCallback(() => {
@@ -54,50 +68,38 @@ export const usePredefinedModelsSelection = () => {
     }
   }, [])
 
-  // Selected category state
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(getSavedCategoryId)
+  // The user's explicit in-session pick (null until they tap a category tab).
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null)
 
-  // Determine initial category based on saved value, config, or first available
-  const initialCategory = useMemo(() => {
+  // Default when the user hasn't picked this session. preferredCategoryId from
+  // config wins; only when it's absent do we fall back to the saved selection;
+  // then the first available. Recomputed when categories/config arrive, so a
+  // late RPC config still applies (the choice isn't frozen on first render).
+  const defaultCategoryId = useMemo(() => {
     if (categories.length === 0) return null
 
-    const savedCategoryId = getSavedCategoryId()
-
-    // Priority 1: Saved category (if exists in current list)
-    if (savedCategoryId) {
-      const saved = categories.find((cat) => cat.category === savedCategoryId)
-      if (saved) return saved.category
+    // Config-preferred takes priority; saved value is the fallback only when no
+    // preferredCategoryId is configured.
+    const candidate = preferredCategoryId || getSavedCategoryId()
+    if (candidate) {
+      const found = categories.find((cat) => cat.category === candidate)
+      if (found) return found.category
     }
 
-    // Priority 2: Preferred category from config (if exists in the list)
-    if (preferredCategoryId) {
-      const preferred = categories.find((cat) => cat.category === preferredCategoryId)
-      if (preferred) return preferred.category
-    }
-
-    // Priority 3: First category
     return categories[0].category
   }, [categories, preferredCategoryId, getSavedCategoryId])
 
-  // Set initial category when categories load
-  useEffect(() => {
-    if (initialCategory && !selectedCategoryId) {
-      setSelectedCategoryId(initialCategory)
-
-      // Save to sessionStorage
-      try {
-        sessionStorage.setItem(SELECTED_CATEGORY_KEY, initialCategory)
-      } catch {
-        // Ignore errors
-      }
-    }
-  }, [initialCategory, selectedCategoryId])
+  // Category actually shown: the explicit pick wins, otherwise the default. The
+  // default is NOT persisted — only an explicit change is (see
+  // handleCategoryChange) — so an auto-applied default never masks
+  // preferredCategoryId on a later load.
+  const effectiveCategoryId = selectedCategoryId ?? defaultCategoryId
 
   // Get current category data
   const currentCategory = useMemo(() => {
-    if (!selectedCategoryId) return null
-    return categories.find((cat) => cat.category === selectedCategoryId) || null
-  }, [categories, selectedCategoryId])
+    if (!effectiveCategoryId) return null
+    return categories.find((cat) => cat.category === effectiveCategoryId) || null
+  }, [categories, effectiveCategoryId])
 
   // Handle category change
   const handleCategoryChange = useCallback(
@@ -119,7 +121,7 @@ export const usePredefinedModelsSelection = () => {
   const handleModelSelect = useCallback(
     async (model: InputImage) => {
       // Track selection
-      trackModelSelected(model.id, selectedCategoryId || '')
+      trackModelSelected(model.id, effectiveCategoryId || '')
 
       // Close bottom sheet if open
       dispatch(uploadsSlice.actions.setIsBottomSheetOpen(false))
@@ -131,7 +133,7 @@ export const usePredefinedModelsSelection = () => {
       // Start try-on with selected model
       await startTryOn(model)
     },
-    [navigate, startTryOn, trackModelSelected, selectedCategoryId, dispatch],
+    [navigate, startTryOn, trackModelSelected, effectiveCategoryId, dispatch],
   )
 
   // Retry loading (resets state to allow new loading attempt)
@@ -144,7 +146,7 @@ export const usePredefinedModelsSelection = () => {
     // Data
     categories,
     currentCategory,
-    selectedCategoryId,
+    selectedCategoryId: effectiveCategoryId,
 
     // State flags
     isLoading,

--- a/app/src/hooks/results/useImageTone.ts
+++ b/app/src/hooks/results/useImageTone.ts
@@ -1,34 +1,33 @@
 import { useEffect, useState } from 'react'
 
 /**
- * Classifies the bottom band of an image as light or dark, so overlays laid
- * over it (the fit disclaimer strip) can pick a matching appearance, and
- * exposes the band's average color for tinted fills.
+ * Samples the image's bottom-most 1px row, used to render the fit-disclaimer
+ * strip flush under the photo: it returns that row as a (1px-tall) data URL to
+ * stretch behind the strip, the row's average color to tint the fill, and a
+ * light/dark classification so the text picks a matching color.
  *
- * Samples the bottom ~5% of the image into a tiny canvas and averages the
- * perceived luminance. Results are cached per URL; any failure (CORS,
- * decode) classifies as dark — the strip's historical default.
+ * Results are cached per URL; any failure (CORS, decode) classifies as dark
+ * with no strip image — the disclaimer's historical fallback look.
  */
 
 export type ImageTone = 'dark' | 'light'
 
 export interface ImageToneInfo {
   tone: ImageTone
-  /** Average color of the sampled band; null when sampling failed */
+  /** Average color of the sampled bottom row; null when sampling failed */
   averageColor: [number, number, number] | null
+  /** The bottom 1px row as a data URL (width × 1), stretched behind the strip */
+  stripUrl: string | null
 }
 
-const DARK_FALLBACK: ImageToneInfo = { tone: 'dark', averageColor: null }
+const DARK_FALLBACK: ImageToneInfo = { tone: 'dark', averageColor: null, stripUrl: null }
 
-// Average perceived luminance (0..1) above which the band counts as light.
-// Deliberately high: when in doubt the strip must stay in the dark variant —
-// dark text was showing up on fairly dark photo bottoms with a lower value.
-const LIGHT_THRESHOLD = 0.82
-// The disclaimer strip is ~20px over a ~600px image — the bottom 5% band
-const BAND_FRACTION = 0.05
-// Downsample target: averaging needs very few pixels
-const SAMPLE_WIDTH = 32
-const SAMPLE_HEIGHT = 4
+// Average perceived luminance (0..1) above which the row counts as light (light
+// fill + dark text). Lowered so mid-bright photo bottoms get the light variant.
+const LIGHT_THRESHOLD = 0.7
+// Horizontal resolution of the sampled bottom row: enough to keep a smooth
+// gradient when stretched across the strip, small enough to stay cheap.
+const STRIP_SAMPLE_WIDTH = 128
 
 const toneCache = new Map<string, Promise<ImageToneInfo>>()
 
@@ -43,9 +42,10 @@ const computeTone = (url: string): Promise<ImageToneInfo> =>
         const width = img.naturalWidth || 1
         const height = img.naturalHeight || 1
 
+        const sampleWidth = Math.max(1, Math.min(width, STRIP_SAMPLE_WIDTH))
         const canvas = document.createElement('canvas')
-        canvas.width = SAMPLE_WIDTH
-        canvas.height = SAMPLE_HEIGHT
+        canvas.width = sampleWidth
+        canvas.height = 1
         // willReadFrequently: this canvas exists only to getImageData (read
         // back pixels), so hint the browser to keep it on the CPU
         const ctx = canvas.getContext('2d', { willReadFrequently: true })
@@ -54,20 +54,10 @@ const computeTone = (url: string): Promise<ImageToneInfo> =>
           return
         }
 
-        const bandHeight = Math.max(1, Math.round(height * BAND_FRACTION))
-        ctx.drawImage(
-          img,
-          0,
-          height - bandHeight,
-          width,
-          bandHeight,
-          0,
-          0,
-          SAMPLE_WIDTH,
-          SAMPLE_HEIGHT,
-        )
+        // Draw only the bottom-most 1px row, scaled to sampleWidth × 1
+        ctx.drawImage(img, 0, height - 1, width, 1, 0, 0, sampleWidth, 1)
 
-        const { data } = ctx.getImageData(0, 0, SAMPLE_WIDTH, SAMPLE_HEIGHT)
+        const { data } = ctx.getImageData(0, 0, sampleWidth, 1)
         let r = 0
         let g = 0
         let b = 0
@@ -84,9 +74,18 @@ const computeTone = (url: string): Promise<ImageToneInfo> =>
         // Perceived luminance, Rec. 709 weights
         const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
 
+        let stripUrl: string | null = null
+        try {
+          stripUrl = canvas.toDataURL('image/png')
+        } catch {
+          // Tainted canvas (cross-origin) — fall back to a tinted/grey fill
+          stripUrl = null
+        }
+
         resolve({
           tone: luminance > LIGHT_THRESHOLD ? 'light' : 'dark',
           averageColor: [r, g, b],
+          stripUrl,
         })
       } catch {
         // Tainted canvas or decode trouble — keep the default look

--- a/app/src/hooks/strings/useDisclaimerStrings.ts
+++ b/app/src/hooks/strings/useDisclaimerStrings.ts
@@ -10,8 +10,7 @@ export const useDisclaimerStrings = () => {
   const strings = fitDisclaimerConfig?.strings
 
   return {
-    fitDisclaimerTitle:
-      strings?.fitDisclaimerTitle ?? 'Generated with AI. Results may vary from real-life fit',
+    fitDisclaimerTitle: strings?.fitDisclaimerTitle ?? 'Results may vary from real-life fit',
     fitDisclaimerDescription:
       strings?.fitDisclaimerDescription ??
       'Virtual try-on is a visualization tool that shows how items might look and may not perfectly represent how the item will fit in reality',

--- a/app/src/pages/4-TryOn/TryOn.module.scss
+++ b/app/src/pages/4-TryOn/TryOn.module.scss
@@ -8,14 +8,15 @@
   overflow: hidden;
 }
 
-// Desktop action row (Figma: Change photo and Try On side by side, half
-// width each, 8px gap, 404px total on the 420px widget, 26px above the
-// widget bottom)
+// Desktop action row (Change photo and Try On side by side, half width each,
+// 8px gap). 52px below the widget bottom: with the 12px gap above and the 50px
+// buttons that's 114px under the image — matching the results screen (72px
+// tiles + 30px disclaimer) so the preview keeps its size across the flow.
 .actions {
   display: flex;
   gap: 8px;
   width: calc(100% - 16px);
-  margin: 0 auto 26px;
+  margin: 0 auto 52px;
 
   .action {
     flex: 1 1 0;
@@ -26,15 +27,27 @@
   }
 }
 
-// The loading status is centered in the whole gap between the image bottom
-// edge and the widget bottom. The negative top margin reaches up into the
-// fillContainer's 16px bottom padding, and the net layout height (92 - 16)
-// equals the action row box (50 + 26) so the preview doesn't shift.
+// The loading status is centered in the whole gap between the image bottom edge
+// and the widget bottom. The negative top margin reaches up into the
+// fillContainer's bottom padding so the row spans the full area the action row
+// occupies (114px desktop) and the preview doesn't shift.
 .loadingRow {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 92px;
+  height: 114px;
   width: calc(100% - 16px);
-  margin: -16px auto 0;
+  margin: -12px auto 0;
+}
+
+// Mobile keeps the original 92px bottom area (16px padding + 50px button + 26px)
+@media (max-width: 992px) {
+  .actions {
+    margin-bottom: 26px;
+  }
+
+  .loadingRow {
+    height: 92px;
+    margin-top: -16px;
+  }
 }

--- a/app/src/pages/5-Results/Results.module.scss
+++ b/app/src/pages/5-Results/Results.module.scss
@@ -68,27 +68,20 @@
   right: 12px;
 }
 
-// Like/dislike as their own vertical column, bottom-right, sitting above the
-// 20px disclaimer strip (Figma: bottom 32 = strip 20 + 12 gap)
+// Like/dislike as their own vertical column at the photo's bottom-right (the
+// disclaimer is no longer overlaid on the image, so they sit near its edge)
 .feedback {
   position: absolute;
-  bottom: 32px;
+  bottom: 12px;
   right: 12px;
   z-index: 2;
   flex-direction: column;
 }
 
-.disclaimer {
-  display: flex;
-  justify-content: center;
-  margin-top: 26px;
-  margin-bottom: 12px;
-}
-
 // Desktop (Figma): the image fills the widget edge-to-edge — 8px sides,
-// 8px below the navbar, 10px gap to the action tiles
+// 8px below the navbar, 12px gap to the action tiles
 .fillContainer {
-  padding: 8px 8px 10px;
+  padding: 8px 8px 12px;
 }
 
 .fillContent {
@@ -126,12 +119,11 @@
   }
 }
 
-// Like/dislike sit flush with the image's right edge, 5px above the
-// 20px disclaimer strip (Figma: bottom 25px); the icons' own 4px
-// padding provides the visual inset
+// Like/dislike at the photo's bottom-right (Figma 12340-33737: bottom 8px);
+// the icons' own 4px padding provides the visual inset
 .feedbackOverlay {
   position: absolute;
-  bottom: 25px;
+  bottom: 8px;
   // 6px gap from the widget's right edge to the dislike button (Figma)
   right: 6px;
   z-index: 2;

--- a/app/src/pages/5-Results/ResultsDesktop.tsx
+++ b/app/src/pages/5-Results/ResultsDesktop.tsx
@@ -1,23 +1,19 @@
 import React from 'react'
 import { ResultActions, Disclaimer, Flex, RemoteImage, Feedback } from '@/components'
-import { useResultsGallery, useImageTone } from '@/hooks'
+import { useResultsGallery } from '@/hooks'
 import { useAppDispatch } from '@/store/store'
 import { galleryModalSlice } from '@/store/slices/galleryModalSlice'
 import { combineClassNames } from '@/utils'
 import styles from './Results.module.scss'
 
 /**
- * Desktop version of the results page (Figma): the image fills the widget
- * edge-to-edge with the disclaimer strip and feedback icons laid over it,
- * and a row of action tiles below
+ * Desktop version of the results page (Figma 12340-33737): the image fills the
+ * widget edge-to-edge with the feedback icons laid over it, a row of action
+ * tiles below, and the fit disclaimer as a footnote at the very bottom.
  */
 export default function ResultsDesktop() {
   const dispatch = useAppDispatch()
   const { currentImage, images } = useResultsGallery()
-  // Light image bottom → light disclaimer strip with dark text, tinted with
-  // the photo's average bottom color. Null while still computing — the strip
-  // stays hidden instead of flashing the wrong variant.
-  const toneInfo = useImageTone(currentImage?.url)
 
   const openFullScreen = () => {
     if (!currentImage) return
@@ -52,10 +48,10 @@ export default function ResultsDesktop() {
             className={styles.feedbackOverlay}
           />
         )}
-        {toneInfo && <Disclaimer overlay tone={toneInfo.tone} tint={toneInfo.averageColor} />}
       </Flex>
 
       {currentImage && <ResultActions activeGeneratedImageUrl={currentImage.url} />}
+      {currentImage && <Disclaimer variant="plain" />}
     </main>
   )
 }

--- a/app/src/pages/5-Results/ResultsMobile.tsx
+++ b/app/src/pages/5-Results/ResultsMobile.tsx
@@ -108,15 +108,24 @@ export default function ResultsMobile() {
               {currentImage && (
                 <Feedback generatedImageUrl={currentImage.url} className={styles.feedback} />
               )}
-              {toneInfo && (
-                <Disclaimer overlay tone={toneInfo.tone} tint={toneInfo.averageColor} />
-              )}
             </Flex>
 
             {/* No Add to cart button yet, but its space is reserved so the
                 result image keeps the same height as the loading screen (no
-                jump on finish). For now it holds the Powered by footer. */}
+                jump on finish). It holds the fit disclaimer — flush under the
+                photo, full-width, its background the photo's stretched bottom
+                row — and the Powered by footer. Keeping the disclaimer inside
+                this reserve (not as its own row) is what stops the image from
+                shrinking. */}
             <div className={styles.cartReserve}>
+              {toneInfo && (
+                <Disclaimer
+                  variant="strip"
+                  tone={toneInfo.tone}
+                  tint={toneInfo.averageColor}
+                  stripUrl={toneInfo.stripUrl}
+                />
+              )}
               <PoweredBy />
             </div>
 

--- a/app/src/store/slices/tryOnSlice/index.ts
+++ b/app/src/store/slices/tryOnSlice/index.ts
@@ -8,4 +8,5 @@ export {
   generatedImageUrlSelector,
   productIdsSelector,
   tryOnModeSelector,
+  tryOnPreferredCategoryIdSelector,
 } from './selectors'

--- a/app/src/store/slices/tryOnSlice/selectors.ts
+++ b/app/src/store/slices/tryOnSlice/selectors.ts
@@ -8,3 +8,5 @@ export const operationIdSelector = (state: RootState) => state.tryOn.operationId
 export const generatedImageUrlSelector = (state: RootState) => state.tryOn.generatedImageUrl
 export const productIdsSelector = (state: RootState) => state.tryOn.productIds
 export const tryOnModeSelector = (state: RootState) => state.tryOn.mode
+export const tryOnPreferredCategoryIdSelector = (state: RootState) =>
+  state.tryOn.preferredCategoryId

--- a/app/src/store/slices/tryOnSlice/tryOnSlice.ts
+++ b/app/src/store/slices/tryOnSlice/tryOnSlice.ts
@@ -16,6 +16,10 @@ export interface TryOnState {
   productIds: string[]
   // Arrives with productIds on every tryOn RPC and shares their lifecycle
   mode: AiutaMode
+  // Product gender from the tryOn request → default predefined-model category
+  // for this try-on (overrides the configured preferredCategoryId). null when
+  // the request carried no gender.
+  preferredCategoryId: string | null
 }
 
 const initialState: TryOnState = {
@@ -27,6 +31,7 @@ const initialState: TryOnState = {
   generatedImageUrl: '',
   productIds: [],
   mode: 'general',
+  preferredCategoryId: null,
 }
 
 export const tryOnSlice = createSlice({
@@ -82,6 +87,10 @@ export const tryOnSlice = createSlice({
 
     setMode: (state, action: PayloadAction<AiutaMode>) => {
       state.mode = action.payload
+    },
+
+    setPreferredCategoryId: (state, action: PayloadAction<string | null>) => {
+      state.preferredCategoryId = action.payload
     },
 
     resetTryOnState: (state) => {

--- a/app/src/styles/typeset.css
+++ b/app/src/styles/typeset.css
@@ -28,7 +28,7 @@
 /* Titles */
 .aiuta-title-l {
   font-family: var(--aiuta-typeface);
-  font-size: 24px;
+  font-size: 22px;
   font-style: normal;
   font-weight: 600;
   line-height: 1; /* Figma: lineHeight 100% */
@@ -63,7 +63,7 @@
 
 .aiuta-label-footnote {
   font-family: var(--aiuta-typeface);
-  font-size: 12px;
+  font-size: 11px;
   font-style: normal;
   font-weight: 400;
   line-height: 18px;

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -92,8 +92,8 @@ export default function App() {
       .finally(() => setLoadingOutfits(false))
   }, [loadSkuPage])
 
-  const tryOn = (productId: string | string[], mode?: AiutaMode) => {
-    void getAiuta().then((sdk) => sdk.tryOn(productId, mode))
+  const tryOn = (productId: string | string[], mode?: AiutaMode, gender?: string) => {
+    void getAiuta().then((sdk) => sdk.tryOn(productId, { mode, gender }))
   }
 
   // Gear-menu toggle: when on, only items explicitly flagged
@@ -152,7 +152,11 @@ export default function App() {
             onTryOn={tryOn}
           />
         ) : (
-          <OutfitList outfits={outfits} loading={loadingOutfits} onTryOn={tryOn} />
+          <OutfitList
+            outfits={outfits}
+            loading={loadingOutfits}
+            onTryOn={(skuIds, gender) => tryOn(skuIds, 'general', gender)}
+          />
         )}
       </div>
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -21,6 +21,19 @@ import type { AiutaMode } from '@sdk/index'
 // the end (Array.prototype.sort is stable)
 const byCatalogOrder = (a: CatalogItem, b: CatalogItem) => a.order - b.order
 
+type TabValue = 'single' | 'outfit'
+
+const TABS: { value: TabValue; label: string }[] = [
+  { value: 'single', label: 'Single-Item Try-On' },
+  { value: 'outfit', label: 'Outfit Visualization' },
+]
+
+// Single-Item Try-On is the default when the hash is missing/unrecognized.
+const readTabFromHash = (): TabValue => {
+  const hash = window.location.hash.replace(/^#/, '')
+  return TABS.some((tab) => tab.value === hash) ? (hash as TabValue) : 'single'
+}
+
 export default function App() {
   const [skus, setSkus] = useState<CatalogItem[]>([])
   const [outfits, setOutfits] = useState<OutfitsApiResponse[]>([])
@@ -91,21 +104,56 @@ export default function App() {
     [tryOnFilterEnabled, skus],
   )
 
+  // Single-Item Try-On is the default tab; outfits (which load slowly) sit
+  // behind their own tab so they never hold up the main catalog view. They
+  // keep loading in the background so the tab is ready when opened. The active
+  // tab is mirrored in the URL hash so it survives a refresh / deep link.
+  const [activeTab, setActiveTab] = useState<TabValue>(readTabFromHash)
+
+  const selectTab = (tab: TabValue) => {
+    setActiveTab(tab)
+    window.location.hash = tab
+  }
+
+  // Keep the tab in sync with the hash for back/forward and manual edits.
+  useEffect(() => {
+    const onHashChange = () => setActiveTab(readTabFromHash())
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
   return (
     <>
       <Header />
       <div className="page-container">
-        <OutfitList outfits={outfits} loading={loadingOutfits} onTryOn={tryOn} />
+        <div className="tabs" role="tablist" aria-label="Try-on mode">
+          {TABS.map((tab) => (
+            <button
+              key={tab.value}
+              type="button"
+              role="tab"
+              className={'tab' + (activeTab === tab.value ? ' tab--active' : '')}
+              aria-selected={activeTab === tab.value}
+              onClick={() => selectTab(tab.value)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
 
-        <SkuList
-          items={visibleSkus}
-          loading={loadingList}
-          loadingMore={loadingMoreSkus}
-          hasMore={hasMoreSkus}
-          onLoadMore={loadMoreSkus}
-          apiKey={demoConfig.apiKey}
-          onTryOn={tryOn}
-        />
+        {activeTab === 'single' ? (
+          <SkuList
+            items={visibleSkus}
+            loading={loadingList}
+            loadingMore={loadingMoreSkus}
+            hasMore={hasMoreSkus}
+            onLoadMore={loadMoreSkus}
+            apiKey={demoConfig.apiKey}
+            onTryOn={tryOn}
+          />
+        ) : (
+          <OutfitList outfits={outfits} loading={loadingOutfits} onTryOn={tryOn} />
+        )}
       </div>
 
       {/* Desktop-only copy pinned to the top-right corner (the header copy is

--- a/demo/src/components/OutfitCard.tsx
+++ b/demo/src/components/OutfitCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useImageGradient } from '../hooks/useImageGradient'
 import { createRipple } from '../utils/ripple'
 import RetryImage from './RetryImage'
@@ -10,52 +10,15 @@ interface Props {
   onTryOn: (outfit: OutfitsApiResponse) => void
 }
 
-// Delay before the model image shows, so sweeping the cursor across cards
-// doesn't flicker — only a deliberate hover reveals it.
-const HOVER_DELAY_MS = 180
-
-// Only reveal the model image where there's a real hovering pointer. On touch a
-// tap fires mouseenter with no matching mouseleave, so the image would "stick".
-const SUPPORTS_HOVER =
-  typeof window !== 'undefined' &&
-  typeof window.matchMedia === 'function' &&
-  window.matchMedia('(hover: hover) and (pointer: fine)').matches
-
 // The outfits API serializes missing images as a URL ending in "None" (Python
 // None stringified by the backend), which 404s — treat those as absent.
 const isUsableImage = (url?: string): boolean => Boolean(url) && !/\/None$/i.test(url ?? '')
 
 export default function OutfitCard({ outfit, onTryOn }: Props) {
   const { getBgStyle, isMultiplied, initGradient } = useImageGradient()
-  const [hovered, setHovered] = useState(false)
   const [collageFailed, setCollageFailed] = useState(false)
-  const [modelLoaded, setModelLoaded] = useState(false)
-  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const clearHoverTimer = () => {
-    if (hoverTimer.current) {
-      clearTimeout(hoverTimer.current)
-      hoverTimer.current = null
-    }
-  }
-
-  const handleEnter = () => {
-    if (!SUPPORTS_HOVER) return
-    clearHoverTimer()
-    hoverTimer.current = setTimeout(() => setHovered(true), HOVER_DELAY_MS)
-  }
-
-  const handleLeave = () => {
-    clearHoverTimer()
-    setHovered(false)
-  }
-
-  // Clear any pending hover timer on unmount.
-  useEffect(() => clearHoverTimer, [])
-
-  const hasModelImage = isUsableImage(outfit.model_image_url)
   const showCollage = isUsableImage(outfit.collage_image_url) && !collageFailed
-  const hideMedia = hasModelImage && hovered && modelLoaded
 
   const gridItems = useMemo(
     () =>
@@ -66,86 +29,87 @@ export default function OutfitCard({ outfit, onTryOn }: Props) {
     [outfit.items],
   )
   const gridSize = Math.min(Math.max(outfit.items.length, 1), 6)
-  const subtitle = [outfit.style, `${outfit.items.length} Items`].filter(Boolean).join(' • ')
+  const itemCount = outfit.items.length
+
+  // The API exposes no outfit name; the occasion tag (e.g. "Office Hours") is
+  // the closest human-readable title, with style as a fallback.
+  const title = outfit.tags?.occasion || outfit.tags?.style || 'Outfit'
+
+  // Same corner-gradient / white-bg multiply fill as the SKU cards, keyed by the
+  // collage URL (the outfit's lead image).
+  const collageKey = outfit.collage_image_url ?? ''
 
   return (
-    <div
-      className="outfit-card"
-      onClick={() => onTryOn(outfit)}
-      onPointerDown={createRipple}
-      onMouseEnter={handleEnter}
-      onMouseLeave={handleLeave}
-    >
-      {hasModelImage ? (
-        <RetryImage
-          src={outfit.model_image_url}
-          alt={outfit.title}
-          loading="lazy"
-          // No icon: a failed model image just disables the hover reveal.
-          fallback="none"
-          className={
-            'outfit-card__model-image' + (hovered ? ' outfit-card__model-image--visible' : '')
-          }
-          onLoad={() => setModelLoaded(true)}
-          onError={() => setModelLoaded(false)}
-        />
-      ) : null}
-
-      <div className={'outfit-card__media' + (hideMedia ? ' outfit-card__media--hidden' : '')}>
-        {showCollage ? (
-          <RetryImage
-            src={outfit.collage_image_url}
-            alt={outfit.title}
-            loading="lazy"
-            // No icon: a failed collage falls back to the item grid below.
-            fallback="none"
-            className="outfit-card__collage-image"
-            onError={() => setCollageFailed(true)}
-          />
-        ) : (
-          <div className={`outfit-card__grid outfit-card__grid--${gridSize}`}>
-            {gridItems.map(({ item, imageUrl }) => (
-              <div
-                key={item.sku_id}
-                className="outfit-card__grid-item"
-                style={getBgStyle(item.sku_id)}
-              >
-                <RetryImage
-                  src={imageUrl}
-                  alt={item.title}
-                  loading="lazy"
-                  className={
-                    'outfit-card__image' +
-                    (isMultiplied(item.sku_id) ? ' outfit-card__image--multiply' : '')
-                  }
-                  onLoad={() => void initGradient(item.sku_id, imageUrl)}
-                />
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      <div className="outfit-card__footer">
-        <div className="outfit-card__meta">
-          <div className="outfit-card__title">{outfit.title}</div>
-          <div className="outfit-card__subtitle">{subtitle}</div>
-        </div>
-        <button
-          type="button"
-          className="btn btn--white outfit-card__try-on"
-          onPointerDown={(event) => {
-            event.stopPropagation()
-            createRipple(event)
-          }}
-          onClick={(event) => {
-            event.stopPropagation()
-            onTryOn(outfit)
-          }}
+    <div className="outfit-card outfit-card--clickable" onClick={() => onTryOn(outfit)}>
+      <div className="outfit-card__inner" onPointerDown={createRipple}>
+        <div
+          className="outfit-card__item"
+          style={showCollage ? getBgStyle(collageKey) : undefined}
         >
-          <TryOnIcon className="btn__icon" />
-          <span>Try On</span>
-        </button>
+          {showCollage ? (
+            <RetryImage
+              src={outfit.collage_image_url}
+              alt={title}
+              loading="lazy"
+              // No icon: a failed collage falls back to the item grid below.
+              fallback="none"
+              className={
+                'outfit-card__image' +
+                (isMultiplied(collageKey) ? ' outfit-card__image--multiply' : '')
+              }
+              onLoad={() => void initGradient(collageKey, outfit.collage_image_url)}
+              onError={() => setCollageFailed(true)}
+            />
+          ) : (
+            <div className={`outfit-card__grid outfit-card__grid--${gridSize}`}>
+              {gridItems.map(({ item, imageUrl }) => (
+                <div
+                  key={item.sku_id}
+                  className="outfit-card__grid-item"
+                  style={getBgStyle(item.sku_id)}
+                >
+                  <RetryImage
+                    src={imageUrl}
+                    alt={item.title}
+                    loading="lazy"
+                    className={
+                      'outfit-card__image' +
+                      (isMultiplied(item.sku_id) ? ' outfit-card__image--multiply' : '')
+                    }
+                    onLoad={() => void initGradient(item.sku_id, imageUrl)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Inside the fixed-ratio image box, so the button sits at the same
+              spot regardless of the title line count (like the SKU cards) */}
+          <div className="outfit-card__overlay">
+            <button
+              type="button"
+              className="btn btn--white outfit-card__try-on"
+              onPointerDown={(event) => {
+                event.stopPropagation()
+                createRipple(event)
+              }}
+              onClick={(event) => {
+                event.stopPropagation()
+                onTryOn(outfit)
+              }}
+            >
+              <TryOnIcon className="btn__icon" />
+              <span>Try On</span>
+            </button>
+          </div>
+        </div>
+
+        <div className="outfit-card__content">
+          <div className="outfit-card__title">{title}</div>
+          <div className="outfit-card__count">
+            {itemCount} {itemCount === 1 ? 'item' : 'items'}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/demo/src/components/OutfitList.tsx
+++ b/demo/src/components/OutfitList.tsx
@@ -1,16 +1,7 @@
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import React from 'react'
 import OutfitCard from './OutfitCard'
 import Spinner from './Spinner'
 import type { OutfitsApiResponse } from '../models/product'
-
-const ALL_FILTER_VALUE = 'all'
 
 interface Props {
   outfits: OutfitsApiResponse[]
@@ -19,283 +10,33 @@ interface Props {
 }
 
 export default function OutfitList({ outfits, loading, onTryOn }: Props) {
-  const viewportRef = useRef<HTMLDivElement | null>(null)
-  const dotsViewportRef = useRef<HTMLDivElement | null>(null)
-  const dotsTrackRef = useRef<HTMLDivElement | null>(null)
-  const [activeFilter, setActiveFilter] = useState<string>(ALL_FILTER_VALUE)
-  // Fractional scroll position (0 = first card, 1 = second, ...) so the pager can
-  // render the in-between state continuously while dragging.
-  const [progress, setProgress] = useState(0)
-  const [canScrollPrev, setCanScrollPrev] = useState(false)
-  const [canScrollNext, setCanScrollNext] = useState(false)
-  const [hasOverflow, setHasOverflow] = useState(false)
-
-  const filters = useMemo(() => {
-    const styles = Array.from(
-      new Set(
-        outfits
-          .map((outfit) => outfit.style?.trim())
-          .filter((style): style is string => Boolean(style)),
-      ),
-    )
-    return [
-      { value: ALL_FILTER_VALUE, label: 'All occasions' },
-      ...styles.map((style) => ({ value: style, label: style })),
-    ]
-  }, [outfits])
-
-  const filteredOutfits = useMemo(() => {
-    if (activeFilter === ALL_FILTER_VALUE) return outfits
-    return outfits.filter((outfit) => outfit.style?.trim() === activeFilter)
-  }, [outfits, activeFilter])
-
-  // Reset to "all" if the active filter disappears after a catalog refresh.
-  useEffect(() => {
-    if (!filters.some((filter) => filter.value === activeFilter)) {
-      setActiveFilter(ALL_FILTER_VALUE)
-    }
-  }, [filters, activeFilter])
-
-  const getCards = useCallback(
-    (): HTMLElement[] =>
-      Array.from(viewportRef.current?.querySelectorAll<HTMLElement>('.outfit__card') ?? []),
-    [],
-  )
-
-  const getLeadingOffset = useCallback((): number => getCards()[0]?.offsetLeft ?? 0, [getCards])
-
-  const getScrollStep = useCallback((): number => {
-    const viewport = viewportRef.current
-    const firstCard = getCards()[0]
-    if (!viewport || !firstCard) return 0
-    const track = viewport.querySelector<HTMLElement>('.outfit__track')
-    const style = track ? window.getComputedStyle(track) : null
-    const gap = style ? Number.parseFloat(style.columnGap || style.gap || '0') : 0
-    return firstCard.getBoundingClientRect().width + gap
-  }, [getCards])
-
-  const updateScrollState = useCallback(() => {
-    const viewport = viewportRef.current
-    if (!viewport) return
-    const { scrollLeft, clientWidth, scrollWidth } = viewport
-    const cards = getCards()
-
-    setCanScrollPrev(scrollLeft > 1)
-    setCanScrollNext(scrollLeft + clientWidth < scrollWidth - 1)
-    setHasOverflow(scrollWidth > clientWidth + 1)
-
-    if (!cards.length) {
-      setProgress(0)
-      return
-    }
-
-    // Fractional card index under the left edge (cards are evenly spaced).
-    const step = cards.length > 1 ? cards[1].offsetLeft - cards[0].offsetLeft : 0
-    const raw = step > 0 ? scrollLeft / step : 0
-    setProgress(Math.max(0, Math.min(raw, cards.length - 1)))
-  }, [getCards])
-
-  useEffect(() => {
-    updateScrollState()
-    window.addEventListener('resize', updateScrollState)
-    return () => window.removeEventListener('resize', updateScrollState)
-  }, [updateScrollState])
-
-  // Re-evaluate scroll affordances and snap to the start when the list changes.
-  useEffect(() => {
-    viewportRef.current?.scrollTo({ left: 0, behavior: 'auto' })
-    setProgress(0)
-    const id = window.requestAnimationFrame(updateScrollState)
-    return () => window.cancelAnimationFrame(id)
-  }, [filteredOutfits, loading, updateScrollState])
-
-  // Pager position: the dots track is clipped (no scroll) and slides so the
-  // active dot stays centered, but clamped to the edges so it never detaches
-  // from them (iOS page-control style). When the dots fit, the whole track is
-  // just centered.
-  const positionDots = useCallback(() => {
-    const viewport = dotsViewportRef.current
-    const track = dotsTrackRef.current
-    if (!viewport || !track) return
-    const dots = Array.from(track.children) as HTMLElement[]
-    if (!dots.length) {
-      track.style.transform = 'translateX(0)'
-      return
-    }
-    const viewportWidth = viewport.clientWidth
-    const trackWidth = track.scrollWidth
-
-    let offset: number
-    if (trackWidth <= viewportWidth) {
-      offset = (viewportWidth - trackWidth) / 2
-    } else {
-      const lo = Math.max(0, Math.min(Math.floor(progress), dots.length - 1))
-      const hi = Math.min(lo + 1, dots.length - 1)
-      const center = (dot: HTMLElement) => dot.offsetLeft + dot.offsetWidth / 2
-      const activeCenter = center(dots[lo]) + (center(dots[hi]) - center(dots[lo])) * (progress - lo)
-      // Clamp so the track edges never pull away from the viewport edges
-      offset = Math.min(0, Math.max(viewportWidth - trackWidth, viewportWidth / 2 - activeCenter))
-    }
-    track.style.transform = `translateX(${offset}px)`
-  }, [progress])
-
-  useLayoutEffect(positionDots, [positionDots, filteredOutfits])
-
-  useEffect(() => {
-    window.addEventListener('resize', positionDots)
-    return () => window.removeEventListener('resize', positionDots)
-  }, [positionDots])
-
-  const goPrev = () => {
-    const step = getScrollStep()
-    if (step) viewportRef.current?.scrollBy({ left: -step, behavior: 'smooth' })
-  }
-
-  const goNext = () => {
-    const step = getScrollStep()
-    if (step) viewportRef.current?.scrollBy({ left: step, behavior: 'smooth' })
-  }
-
-  const setIndex = (index: number) => {
-    const viewport = viewportRef.current
-    const targetCard = getCards()[index]
-    if (!viewport || !targetCard) return
-    viewport.scrollTo({ left: targetCard.offsetLeft - getLeadingOffset(), behavior: 'smooth' })
-  }
-
-  if (!outfits.length && !loading) return null
-
-  const hasControls = !loading && hasOverflow
-  const showFilters = filters.length > 1 && !loading
-
   return (
     <div className="outfit">
-      <div className="outfit__header">
-        <div className="outfit__title-wrap">
-          <h2 className="outfit__title">Outfit Visualization</h2>
-        </div>
-      </div>
-
-      {/* While loading, assume the catalog has filters and keep the row
-          reserved — it collapses only when the loaded data has none. */}
-      {loading || showFilters || hasControls ? (
-        <div className="outfit__toolbar">
-          {showFilters ? (
-            <div className="outfit__filters" role="tablist" aria-label="Outfit filters">
-              {filters.map((filter) => (
-                <button
-                  key={filter.value}
-                  type="button"
-                  className={
-                    'outfit__filter' +
-                    (activeFilter === filter.value ? ' outfit__filter--active' : '')
-                  }
-                  aria-selected={activeFilter === filter.value}
-                  onClick={() => setActiveFilter(filter.value)}
-                >
-                  {filter.label}
-                </button>
-              ))}
-            </div>
-          ) : null}
-          {hasControls ? (
-            <div className="outfit__controls">
-              <button
-                type="button"
-                className="outfit__control-btn"
-                aria-label="Previous"
-                disabled={!canScrollPrev}
-                onClick={goPrev}
-              >
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    d="M14.5 7l-5 5 5 5"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
-              <button
-                type="button"
-                className="outfit__control-btn"
-                aria-label="Next"
-                disabled={!canScrollNext}
-                onClick={goNext}
-              >
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path
-                    d="M9.5 7l5 5-5 5"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </button>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      <div ref={viewportRef} className="outfit__viewport" onScroll={updateScrollState}>
-        <div className="outfit__track">
-          {loading
-            ? Array.from({ length: 4 }).map((_, index) => (
-                <div className="outfit__card" key={index}>
-                  <div className="outfit__skeleton-card">
+      <div className="outfit-grid">
+        {loading
+          ? Array.from({ length: 4 }).map((_, index) => (
+              <div className="outfit-card" key={index}>
+                <div className="outfit-card__inner">
+                  <div className="outfit-card__loading">
                     <Spinner />
                   </div>
+                  {/* Same content block as a loaded card with a one-line title,
+                      so the grid doesn't shift on load. */}
+                  <div className="outfit-card__content">
+                    <div className="outfit-card__title">
+                      <span className="outfit-card__title-skeleton" aria-hidden="true" />
+                    </div>
+                  </div>
                 </div>
-              ))
-            : filteredOutfits.map((outfit, index) => (
-                <div className="outfit__card" key={index}>
-                  <OutfitCard
-                    outfit={outfit}
-                    onTryOn={(o) => onTryOn(o.items.map((i) => i.sku_id))}
-                  />
-                </div>
-              ))}
-        </div>
-      </div>
-
-      {/* Always rendered so its height is reserved on mobile (no jump in the gap
-          to the next section when a filter has too few outfits to page). The
-          outer element clips; the track slides to keep the active dot centered. */}
-      <div className="outfit__dots" ref={dotsViewportRef}>
-        <div
-          className="outfit__dots-track"
-          ref={dotsTrackRef}
-          role="tablist"
-          aria-label="Outfit pagination"
-        >
-          {!loading &&
-            filteredOutfits.length > 1 &&
-            filteredOutfits.map((_, index) => {
-            // Closeness of this dot to the current scroll position (1 = exactly
-            // here, 0 = a full card away) — drives the pill width/shade so the
-            // active indicator glides between dots as you drag.
-            const t = Math.max(0, 1 - Math.abs(index - progress))
-            const shade = Math.round(217 - 200 * t)
-            return (
-              <button
+              </div>
+            ))
+          : outfits.map((outfit, index) => (
+              <OutfitCard
                 key={index}
-                type="button"
-                aria-label={`Go to outfit ${index + 1}`}
-                aria-selected={Math.round(progress) === index}
-                className="outfit__dot"
-                style={{
-                  width: `${6 + 18 * t}px`,
-                  backgroundColor: `rgb(${shade}, ${shade}, ${shade})`,
-                }}
-                onClick={() => setIndex(index)}
+                outfit={outfit}
+                onTryOn={(o) => onTryOn(o.items.map((i) => i.sku_id))}
               />
-            )
-            })}
-        </div>
+            ))}
       </div>
     </div>
   )

--- a/demo/src/components/OutfitList.tsx
+++ b/demo/src/components/OutfitList.tsx
@@ -6,7 +6,7 @@ import type { OutfitsApiResponse } from '../models/product'
 interface Props {
   outfits: OutfitsApiResponse[]
   loading: boolean
-  onTryOn: (skuIds: string[]) => void
+  onTryOn: (skuIds: string[], gender?: string) => void
 }
 
 export default function OutfitList({ outfits, loading, onTryOn }: Props) {
@@ -34,7 +34,7 @@ export default function OutfitList({ outfits, loading, onTryOn }: Props) {
               <OutfitCard
                 key={index}
                 outfit={outfit}
-                onTryOn={(o) => onTryOn(o.items.map((i) => i.sku_id))}
+                onTryOn={(o) => onTryOn(o.items.map((i) => i.sku_id), o.tags?.gender)}
               />
             ))}
       </div>

--- a/demo/src/components/SkuList.tsx
+++ b/demo/src/components/SkuList.tsx
@@ -81,7 +81,6 @@ export default function SkuList({
 
   return (
     <section className="skus">
-      <h2>Single-Item Try-On</h2>
       <div className="sku-grid">
         {loading && !items.length
           ? Array.from({ length: 8 }).map((_, index) => <SkeletonCard key={index} />)

--- a/demo/src/components/SkuList.tsx
+++ b/demo/src/components/SkuList.tsx
@@ -15,7 +15,7 @@ interface Props {
   hasMore: boolean
   onLoadMore: () => void
   apiKey: string
-  onTryOn: (skuId: string, mode?: AiutaMode) => void
+  onTryOn: (skuId: string, mode?: AiutaMode, gender?: string) => void
 }
 
 function SkeletonCard() {
@@ -90,7 +90,7 @@ export default function SkuList({
                 <div
                   className="sku-card sku-card--clickable"
                   key={item.sku_id}
-                  onClick={() => onTryOn(item.sku_id, item.mode)}
+                  onClick={() => onTryOn(item.sku_id, item.mode, item.gender)}
                 >
                   <div className="sku-card__inner" onPointerDown={createRipple}>
                     <div className="sku-card__item" style={getBgStyle(item.sku_id)}>
@@ -116,7 +116,7 @@ export default function SkuList({
                           }}
                           onClick={(event) => {
                             event.stopPropagation()
-                            onTryOn(item.sku_id, item.mode)
+                            onTryOn(item.sku_id, item.mode, item.gender)
                           }}
                         >
                           <TryOnIcon className="btn__icon" />

--- a/demo/src/models/product.ts
+++ b/demo/src/models/product.ts
@@ -63,12 +63,17 @@ export interface CatalogItem {
 // The suggested_outfits endpoint still returns items in the legacy SkuItem
 // shape (with descriptive_image_urls) — see the OpenAPI spec
 
+export interface OutfitTags {
+  gender?: string
+  /** Human-readable occasion, used as the card title (e.g. "Office Hours") */
+  occasion?: string
+  style?: string
+}
+
 export interface OutfitsApiResponse {
   items: SkuItem[]
-  model_image_url: string
   collage_image_url: string
-  title: string
-  style: string
+  tags: OutfitTags
 }
 
 export interface SkuItem {

--- a/demo/src/models/product.ts
+++ b/demo/src/models/product.ts
@@ -23,6 +23,7 @@ export interface UnifiedSkuItem {
     description?: string | null
     brand?: string | null
     category?: string | null
+    gender?: string | null
     image_urls?: string[] | null
     store_url?: string | null
     extra?: SkuItemExtra | null
@@ -51,6 +52,8 @@ export interface CatalogItem {
   title: string
   brand?: string
   image_url: string
+  /** Product gender (e.g. "male" / "female"), used to preselect the model category */
+  gender?: string
   /** Try-on mode derived from the backend category (shoes vs everything else) */
   mode: 'general' | 'shoes'
   /** Sort key from extra.order; items without one go last */

--- a/demo/src/sdk.ts
+++ b/demo/src/sdk.ts
@@ -18,6 +18,18 @@ import type { AiutaConfiguration } from '@sdk/index'
 
 const aiutaConfiguration: AiutaConfiguration = {
   auth: { apiKey: demoConfig.apiKey },
+  features: {
+    imagePicker: {
+      predefinedModels: {
+        // Demo: default to the male models and show Men before Women.
+        // (The backend tags models as "male" / "female".)
+        data: {
+          preferredCategoryId: 'male',
+          preferredCategoryOrder: ['male', 'female'],
+        },
+      },
+    },
+  },
   userInterface: {
     theme: {
       // - Poppins as the preferred SDK typeface, matching the demo page.

--- a/demo/src/styles/index.scss
+++ b/demo/src/styles/index.scss
@@ -65,8 +65,58 @@ img {
   width: 100%;
   max-width: 1350px;
   box-sizing: border-box;
-  padding: 40px 25px 120px;
+  padding: 28px 25px 120px;
   margin: 0 auto;
+}
+
+// Section tabs (Single-Item Try-On / Outfit Visualization). They double as the
+// section heading, so they're sized like the old <h2> titles, with an underline
+// marking the active one.
+.tabs {
+  display: flex;
+  gap: 28px;
+  margin: 0 0 24px;
+  border-bottom: 1px solid #ececef;
+}
+
+.tab {
+  position: relative;
+  padding: 0 0 14px;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  font-size: 22px;
+  font-weight: 500;
+  line-height: 1.2;
+  color: #b6b6be;
+  cursor: pointer;
+  // No transition: switching tabs is instant (no color fade).
+
+  &--active {
+    color: #111;
+  }
+
+  // Sits on top of the row's border so the active tab reads as connected to it
+  &--active::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -1px;
+    height: 2px;
+    background: #111;
+    border-radius: 2px;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      color: #111;
+    }
+  }
+
+  @media (max-width: 599px) {
+    font-size: 18px;
+  }
 }
 
 .btn {
@@ -356,7 +406,7 @@ img {
 /* ----------------------------------------------------------- Single SKU --- */
 
 .skus {
-  margin-top: 40px;
+  margin-top: 0;
 }
 
 .catalog-empty {
@@ -370,7 +420,6 @@ img {
   grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 12px;
   align-items: stretch;
-  margin-top: 20px;
 }
 
 // Invisible infinite-scroll trigger right below the grid; the observer's
@@ -518,281 +567,76 @@ img {
 
 /* -------------------------------------------------------------- Outfits --- */
 
-.outfit {
-  --page-max-width: 1350px;
-  --page-gutter: 25px;
-  --outfit-side-offset: max(
-    var(--page-gutter),
-    calc((100vw - var(--page-max-width)) / 2 + var(--page-gutter))
-  );
+// Outfit cards laid out in the same responsive grid as the SKU cards (no
+// horizontal scroll). Mirrors .sku-grid's columns and breakpoints.
+.outfit-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+  align-items: stretch;
 
-  &__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
+  @media (max-width: 1100px) {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
-  &__title {
-    margin: 0;
-  }
-
-  // Filters on the left, prev/next controls on the right — one shared row.
-  // The filter pills (36px) reserve the row height so it doesn't jump when the
-  // controls appear/disappear between filters.
-  &__toolbar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
-    margin: 28px 0 8px;
-    min-height: 36px;
-  }
-
-  &__controls {
-    display: flex;
-    gap: 8px;
-    flex: 0 0 auto;
-    // Keep the controls pinned right when there are no filters in the row.
-    margin-left: auto;
-  }
-
-  &__control-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 34px;
-    height: 34px;
-    padding: 0;
-    border: 0;
-    border-radius: 999px;
-    background: rgba(248, 248, 250, 1);
-    color: #111;
-    cursor: pointer;
-    transition:
-      background-color 0.2s ease,
-      color 0.2s ease;
-
-    svg {
-      width: 16px;
-      height: 16px;
-      display: block;
-    }
-
-    &:hover {
-      background: rgba(240, 240, 240, 1);
-    }
-
-    &:disabled {
-      color: #c4c4cc;
-      cursor: default;
-    }
-  }
-
-  &__filters {
-    display: flex;
-    flex: 1 1 auto;
-    gap: 12px;
-    // Single scrollable row (no wrap) so the filters stay level with the
-    // prev/next controls; the pager dots/scrollbar already hint at overflow.
-    overflow-x: auto;
-    overflow-y: hidden;
-    scrollbar-width: none;
-
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
-
-  &__filter {
-    min-height: 36px;
-    padding: 8px 18px;
-    border: 0;
-    border-radius: 999px;
-    background: transparent;
-    color: #111;
-    font-family: inherit;
-    font-size: 13px;
-    white-space: nowrap;
-    line-height: 1.2;
-    cursor: pointer;
-    // No transition: fading hover-grey → active-dark (while text fades to white)
-    // flashed grey-on-grey. Tabs switch instantly instead.
-
-    &--active {
-      background: #111;
-      color: #fff;
-    }
-
-    // Hover states only on real pointers — on touch a tap emulates :hover and
-    // flashes the grey background before the active fill lands.
-    @media (hover: hover) {
-      &:hover {
-        background: rgba(17, 17, 17, 0.06);
-      }
-
-      // Hovering the active filter keeps a dark bg (light hover made #fff unreadable).
-      &--active:hover {
-        background: #333;
-      }
-    }
-  }
-
-  &__viewport {
-    // max(…, 300px) keeps the full-bleed aligned once the page hits its 300px
-    // min-width and starts scrolling horizontally
-    width: max(100vw, 300px);
-    overflow-x: auto;
-    overflow-y: visible;
-    margin-left: calc(50% - max(100vw, 300px) / 2);
-    // Leading offset via container padding (not spacer items) so the track gap
-    // can't add a stray gap before the first card. Trailing offset is a margin on
-    // the last card — Safari ignores a scroll container's inline-end padding, but
-    // honours a flex item's margin in the scroll area.
-    padding: 24px 0 24px var(--outfit-side-offset);
-    // `mandatory` always lands on a card start (proximity let it stop mid-card).
-    scroll-snap-type: x mandatory;
-    scroll-padding-left: var(--outfit-side-offset);
-  }
-
-  &__track {
-    display: flex;
-    gap: 16px;
-    width: max-content;
-  }
-
-  &__card {
-    flex: 0 0 min(320px, calc(max(100vw, 300px) - 64px));
-    width: min(320px, calc(max(100vw, 300px) - 64px));
-    scroll-snap-align: start;
-
-    &:last-child {
-      margin-inline-end: var(--outfit-side-offset);
-    }
-  }
-
-  &__skeleton-card {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
-    height: 460px;
-    overflow: hidden;
-    background: #f4f4f5;
-    border-radius: 18px;
-  }
-
-  // Clip viewport: when there are too many dots to fit they're cut off (no
-  // scroll), and the track slides to keep the active one centered (see
-  // OutfitList.positionDots).
-  &__dots {
-    display: none;
-    overflow: hidden;
-    // Reserve the dot height even when empty so the gap below doesn't jump.
-    min-height: 6px;
-  }
-
-  &__dots-track {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: max-content;
-    // translateX is set inline to center the active dot, clamped to the edges
-  }
-
-  &__dot {
-    // width + background are driven inline by scroll progress (see OutfitList)
-    // for a continuous pager; no transition so it tracks the drag in real time.
-    flex-shrink: 0;
-    width: 6px;
-    height: 6px;
-    padding: 0;
-    border: 0;
-    border-radius: 999px;
-    cursor: pointer;
-    background: #d9d9d9;
+  @media (max-width: 860px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   @media (max-width: 599px) {
-    &__filter {
-      min-height: 36px;
-      padding: 8px 14px;
-      font-size: 14px;
-    }
-
-    &__dots {
-      display: block;
-    }
-
-    &__skeleton-card {
-      height: 400px;
-    }
-
-    // The dots pager is the scroll indicator on mobile — hide the scrollbar.
-    &__viewport {
-      scrollbar-width: none;
-
-      &::-webkit-scrollbar {
-        display: none;
-      }
-    }
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
+// Mirrors .sku-card: a grey image box (collage, or an item-image grid when no
+// collage) at a 3/4 ratio, the title + item count below, and a Try On button
+// revealed over the image on hover. Same proportions as the SKU cards.
 .outfit-card {
-  position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  gap: 16px;
-  width: 100%;
-  height: 460px;
-  overflow: hidden;
-  cursor: pointer;
-  background: rgba(241, 241, 241, 0.38);
-  border-radius: 18px;
+  height: 100%;
 
-  &__media {
-    position: relative;
-    z-index: 1;
-    flex: 1;
-    min-height: 0;
-    overflow: hidden;
-    border-radius: 16px;
-    transition: opacity 0.2s ease;
-
-    &--hidden {
-      opacity: 0;
-    }
+  &--clickable {
+    cursor: pointer;
   }
 
-  &__collage-image {
+  &__inner {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    border-radius: 18px;
+  }
+
+  &__item {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 3 / 4;
+    display: flex;
+    overflow: hidden;
+    border-radius: 18px;
+    background: rgba(241, 241, 241, 0.38);
+  }
+
+  &__image {
     width: 100%;
     height: 100%;
     object-fit: contain;
-  }
 
-  &__model-image {
-    position: absolute;
-    inset: 0;
-    z-index: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.2s ease;
-
-    &--visible {
-      opacity: 1;
+    // Same as the SKU cards: only pure-white-background photos blend in
+    &--multiply {
+      mix-blend-mode: multiply;
     }
   }
 
+  // Item-image collage fallback, shown inside the image box when the outfit has
+  // no usable collage image.
   &__grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 6px;
-    padding: 16px 16px 0;
+    padding: 16px;
     width: 100%;
     height: 100%;
   }
@@ -843,87 +687,76 @@ img {
     background-color: #f3f3f3;
   }
 
-  &__image {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-
-    // Same as the SKU cards: only pure-white-background photos blend in
-    &--multiply {
-      mix-blend-mode: multiply;
-    }
-  }
-
-  &__footer {
-    position: relative;
+  // Anchored inside the fixed-ratio image box (like .sku-card__overlay)
+  &__overlay {
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    bottom: 14px;
     z-index: 2;
     display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 12px;
-    padding: 16px;
+    justify-content: center;
+    opacity: 0;
+    transform: translateY(8px);
+    pointer-events: none;
+    transition:
+      opacity 0.2s ease,
+      transform 0.2s ease;
   }
 
-  &__meta {
-    flex: 1;
-    min-width: 0;
+  &__content {
+    padding: 12px 16px 16px;
   }
 
   &__title {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    font-size: 14px;
-    font-weight: 600;
-    line-height: 1.3;
+    font-size: 0.81rem;
+    font-weight: 400;
+    text-align: center;
+    text-transform: capitalize;
   }
 
-  &__subtitle {
-    margin-top: 4px;
-    color: #b7b8c0;
-    font-size: 12px;
-    line-height: 1.3;
+  &__count {
+    margin-top: 2px;
+    font-size: 0.81rem;
+    font-weight: 400;
+    text-align: center;
+    color: #a0a0a8;
+  }
+
+  // Inline bar inside a real __title line box: reserves one text line of height
+  // without hardcoding the computed line height (matches .sku-card).
+  &__title-skeleton {
+    display: inline-block;
+    width: 56%;
+    height: 0.75em;
+    vertical-align: middle;
+    border-radius: 999px;
+    background: #ececef;
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    aspect-ratio: 3 / 4;
+    background: #f4f4f5;
+    border-radius: 18px;
   }
 
   &__try-on {
-    flex-shrink: 0;
-    min-height: 48px;
-    padding: 0 20px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.04);
-    transition:
-      background-color 0.2s ease,
-      box-shadow 0.2s ease,
-      transform 0.2s ease;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.96);
-      box-shadow:
-        0 4px 22px rgba(0, 0, 0, 0.08),
-        inset 0 4px 0 rgba(255, 255, 255, 0.65),
-        inset 0 0 3px rgba(0, 0, 0, 0.1);
-    }
-
-    &:active {
-      box-shadow:
-        0 2px 4px rgba(0, 0, 0, 0.14),
-        inset 0 2px 0 rgba(255, 255, 255, 0.55),
-        inset 0 -2px 0 rgba(255, 255, 255, 0.2);
-      transform: translateY(1px);
-    }
+    width: 100%;
   }
 
-  @media (max-width: 599px) {
-    height: 400px;
-
-    &__footer {
-      align-items: center;
-    }
-
-    &__title {
-      white-space: normal;
-      display: -webkit-box;
-      -webkit-line-clamp: 2;
-      -webkit-box-orient: vertical;
+  // Hover-capable pointers only: on touch an emulated hover would both reveal
+  // the overlay and swallow the first tap's click (iOS), so the card tap starts
+  // the try-on directly without any overlay.
+  @media (hover: hover) {
+    &:hover &__overlay,
+    &__inner:focus-within &__overlay {
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
     }
   }
 }

--- a/demo/src/utils/api.ts
+++ b/demo/src/utils/api.ts
@@ -55,6 +55,7 @@ export const fetchSkuPage = async (offset: number): Promise<SkuPage> => {
         sku_id: item.sku_id,
         title: item.product_info?.title ?? item.sku_id,
         brand: item.product_info?.brand ?? undefined,
+        gender: item.product_info?.gender ?? undefined,
         // Image priority: extra.title_image | source_images[0] | image_urls[0]
         image_url:
           extra.title_image || extra.source_images?.[0] || item.product_info?.image_urls?.[0] || '',

--- a/lib/config/features.ts
+++ b/lib/config/features.ts
@@ -103,7 +103,13 @@ export interface ImagePickerUploadsHistory {
 
 export interface ImagePickerPredefinedModels {
   data?: {
+    /** Category selected by default (e.g. "male" / "female") */
     preferredCategoryId?: string
+    /**
+     * Display order of the category tabs, by category id. Categories not
+     * listed keep their original order, after the listed ones.
+     */
+    preferredCategoryOrder?: string[]
   }
   strings?: {
     predefinedModelsTitle?: string

--- a/lib/config/modes.ts
+++ b/lib/config/modes.ts
@@ -12,6 +12,22 @@
 
 export type AiutaMode = 'general' | 'shoes'
 
+/**
+ * Per-call options for `aiuta.tryOn`. Passed as the second argument instead of a
+ * bare mode string (which is still accepted for backward compatibility).
+ */
+export interface AiutaTryOnOptions {
+  /** Try-on mode driving the UI context; defaults to 'general'. */
+  mode?: AiutaMode
+  /**
+   * Gender of the product being tried on. Selects the matching predefined-model
+   * category by default (the category id equals the gender tag, e.g. "male" /
+   * "female"), overriding `predefinedModels.data.preferredCategoryId` for this
+   * try-on. Omit to fall back to the configured preference.
+   */
+  gender?: string
+}
+
 export interface AiutaModes {
   /**
    * Shoes try-on. Absence keeps the mode enabled with built-in defaults;

--- a/lib/rpc/api/app.ts
+++ b/lib/rpc/api/app.ts
@@ -6,6 +6,12 @@
 
 import type { AiutaMode } from '../../config'
 
+/** Per-request options forwarded with a tryOn call (trailing optional arg). */
+export interface TryOnRequestOptions {
+  /** Product gender → default predefined-model category for this try-on. */
+  gender?: string
+}
+
 /**
  * App API - methods that SDK can call on App
  */
@@ -14,14 +20,19 @@ export interface AppApi {
    * Trigger try-on flow for one or multiple products
    * @param productIds - Single product ID or array of product IDs (for multi-item try-on)
    * @param mode - Try-on mode driving the UI context; defaults to 'general'
+   * @param options - Per-request options (e.g. product gender); optional
    *
    * Supports backward compatibility:
    * - Old SDK: tryOn('product-id')
    * - New SDK: tryOn(['product-id-1', 'product-id-2'], 'shoes')
-   * The mode is a trailing optional arg: an older app ignores it (general
-   * behavior), an older SDK omits it and the app defaults to 'general'.
+   * Both trailing args are optional: an older app ignores them (general
+   * behavior), an older SDK omits them and the app uses its defaults.
    */
-  tryOn(productIds: string | string[], mode?: AiutaMode): Promise<void>
+  tryOn(
+    productIds: string | string[],
+    mode?: AiutaMode,
+    options?: TryOnRequestOptions,
+  ): Promise<void>
 
   /**
    * Wipe all locally stored user data (uploads, generations, consents,

--- a/sdk/aiuta.ts
+++ b/sdk/aiuta.ts
@@ -1,4 +1,4 @@
-import { AiutaConfiguration, AiutaMode } from '@lib/config'
+import { AiutaConfiguration, AiutaMode, AiutaTryOnOptions } from '@lib/config'
 import { createLogger, type Logger } from '@lib/logger'
 import IframeManager from './iframe'
 import MessageHandler from './handler'
@@ -84,9 +84,12 @@ export default class Aiuta {
    * the try-on flow. Tracks analytics for the session.
    *
    * @param productId - Single product ID or array of product IDs to try on
-   * @param mode - Try-on mode driving the UI context (onboarding, photo
-   *   guidance, error texts); the generation flow itself is identical.
-   *   Defaults to 'general'.
+   * @param options - Either a bare mode string (legacy) or an options object:
+   *   - `mode` - Try-on mode driving the UI context (onboarding, photo
+   *     guidance, error texts); the generation flow itself is identical.
+   *     Defaults to 'general'.
+   *   - `gender` - Product gender; defaults the predefined-model picker to the
+   *     matching category for this try-on.
    * @returns Promise that resolves when try-on is initiated
    * @throws Error if this instance has been destroyed. Create a new Aiuta instance instead.
    *
@@ -98,11 +101,14 @@ export default class Aiuta {
    * // Multiple products
    * await aiuta.tryOn(['product-1', 'product-2', 'product-3']);
    *
-   * // Shoes try-on
+   * // Shoes try-on (legacy bare-mode string still works)
    * await aiuta.tryOn('sneakers-42', 'shoes');
+   *
+   * // Options object with the product gender
+   * await aiuta.tryOn('dress-7', { mode: 'general', gender: 'female' });
    * ```
    */
-  async tryOn(productId: string | string[], mode: AiutaMode = 'general') {
+  async tryOn(productId: string | string[], options?: AiutaMode | AiutaTryOnOptions) {
     // Check if instance has been destroyed
     if (this.isDestroyed) {
       const error =
@@ -119,6 +125,12 @@ export default class Aiuta {
       return
     }
 
+    // The second arg is overloaded: a bare mode string (legacy) or an options
+    // object. Normalize both into a single options shape.
+    const opts: AiutaTryOnOptions = typeof options === 'string' ? { mode: options } : (options ?? {})
+    let mode = opts.mode ?? 'general'
+    const gender = opts.gender
+
     // Partners call from untyped JS — fall back instead of breaking the flow
     if (mode !== 'general' && mode !== 'shoes') {
       this.logger.error(`Unknown try-on mode "${mode}", falling back to "general"`)
@@ -133,7 +145,7 @@ export default class Aiuta {
     })
 
     await this.iframeManager.ensureIframe()
-    await this.messageHandler.startTryOn(productIds, mode)
+    await this.messageHandler.startTryOn(productIds, mode, gender)
   }
 
   /**

--- a/sdk/handler.ts
+++ b/sdk/handler.ts
@@ -13,7 +13,7 @@ export default class MessageHandler {
   // handshake completes must await the same connection, not start new ones
   private connecting?: Promise<void>
   // Coalesces rapid tryOn calls: only the latest request is forwarded to the app
-  private pendingTryOn?: { productIds: string[]; mode: AiutaMode }
+  private pendingTryOn?: { productIds: string[]; mode: AiutaMode; gender?: string }
   private tryOnRunning = false
 
   constructor(
@@ -42,10 +42,10 @@ export default class MessageHandler {
     })
   }
 
-  async startTryOn(productIds: string[], mode: AiutaMode) {
+  async startTryOn(productIds: string[], mode: AiutaMode, gender?: string) {
     // Always record the latest request. If a run is already in flight, it will
     // pick this up — only the most recent tryOn reaches the app.
-    this.pendingTryOn = { productIds, mode }
+    this.pendingTryOn = { productIds, mode, gender }
     if (this.tryOnRunning) return
 
     this.tryOnRunning = true
@@ -60,7 +60,11 @@ export default class MessageHandler {
       while (this.pendingTryOn) {
         const next = this.pendingTryOn
         this.pendingTryOn = undefined
-        await this.rpc.app.tryOn(next.productIds, next.mode)
+        await this.rpc.app.tryOn(
+          next.productIds,
+          next.mode,
+          next.gender ? { gender: next.gender } : undefined,
+        )
       }
     } catch (error) {
       this.logger.error('Aiuta RPC tryOn failed:', error)

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -7,6 +7,7 @@ export type {
   AiutaUserInterface,
   AiutaFeatures,
   AiutaMode,
+  AiutaTryOnOptions,
   AiutaModes,
   AiutaShoesMode,
   AiutaAnalytics,


### PR DESCRIPTION
A batch of Web SDK + built-in demo UX fixes (4 commits).

## Built-in demo (`demo/`)
- **Tabs** for the two sections: **Single-Item Try-On** (default) and **Outfit Visualization**. The slow-loading outfits no longer hold up the main catalog view; active tab is stored in the URL hash (survives refresh); switching is instant.
- **Outfit cards** reworked to match SKU cards: grey 3/4 image box (collage or item-grid fallback) with the same gradient/white-bg fill, occasion title + item count below, Try On on hover, same responsive grid (no horizontal scroll). Updated to the current outfits API shape (`tags.{gender,occasion,style}`); the occasion filter row was removed.

## Model-category preselection (SDK)
- New config field `features.imagePicker.predefinedModels.data.preferredCategoryOrder` (orders the category tabs).
- `preferredCategoryId` now takes precedence over the saved session selection; the default is computed (not frozen) so a late RPC config still applies, and an auto-applied default is no longer persisted.
- **`tryOn` second argument** is now either a bare mode string (legacy) or an options object `{ mode?, gender? }` (`AiutaTryOnOptions`). The product `gender` defaults the predefined-model picker to the matching category for that try-on, plumbed through the RPC to a `tryOnSlice` override. Demo reads gender from the API (`product_info.gender` / `tags.gender`).

## Results-screen fit disclaimer
- Text simplified to "Results may vary from real-life fit".
- **Desktop**: a plain footnote at the very bottom, below the action tiles (no longer overlapping the photo). Action tiles 72px, 12px gap to the image, 30px disclaimer box; the TryOn picker/loading bottom area is aligned to the same 114px so the preview doesn't jump across the flow.
- **Mobile**: a full-width strip flush under the photo (18px), inside the reserved area so the image keeps its size. Its background is the photo's stretched bottom 1px row (via `useImageTone`) with a light tint; tint softened (0.64 → 0.4) and light/dark threshold lowered (0.82 → 0.7).

## Note for review
`app/src/styles/typeset.css` includes two changes not authored in the disclaimer work: `aiuta-label-footnote` 12 → 11 (used by the disclaimer) and `aiuta-title-l` 24 → 22 (unrelated global title size) — please confirm both are intended.

## Test plan
- `npm run lint`, `npm run build:app`, `npm run build:sdk`, `npm run build:demo` all clean.
- Manual: demo tabs + outfit grid; model picker defaults to the product gender on try-on; results disclaimer placement on desktop/mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)