### PR TITLE
Design-review follow-ups: zero-state, fullscreen thumbnails, onboarding video

### DIFF
--- a/app/src/components/gallery/ThumbnailList/ThumbnailList.tsx
+++ b/app/src/components/gallery/ThumbnailList/ThumbnailList.tsx
@@ -81,6 +81,14 @@ export const ThumbnailList = ({
   // Wheel delta accumulated past a scroll extreme, to keep "scrolling" the
   // selection at the same pace once the strip itself can't move further.
   const overscrollRef = useRef(0)
+  // The "active zone": the active thumbnail's on-screen position (its center,
+  // measured from the strip's top edge) captured when the selection is set by a
+  // click/keyboard/open. Scrolling then hands the selection to whichever
+  // thumbnail moves into this fixed on-screen spot, so the active stays roughly
+  // where the previous one was.
+  const anchorRef = useRef<number | null>(null)
+  // Whether the initial active item has been revealed/anchored once on open.
+  const didInitRef = useRef(false)
 
   const updateFade = useCallback(() => {
     const el = containerRef.current
@@ -93,61 +101,89 @@ export const ThumbnailList = ({
     setFade((prev) => (prev.top === top && prev.bottom === bottom ? prev : { top, bottom }))
   }, [])
 
-  // Bring the active thumbnail into view only when it's outside the visible area
-  // (scroll the minimum needed, not to the center) — for click / keyboard /
-  // delete. Skipped when the selection change itself came from scrolling.
+  // Capture the active zone when the selection is set by click / keyboard / open
+  // (not by scrolling): remember where the active thumbnail sits on screen so
+  // later scrolling hands the selection to whatever enters that spot. On the
+  // first open only, if the active item is off screen, reveal it first (and
+  // anchor at its revealed position); a user click already sits where it is, so
+  // the strip is left in place and the zone is taken from its current position.
   useEffect(() => {
     if (scrollDrivenRef.current) {
+      // Scroll-driven change: keep the existing zone fixed on screen.
       scrollDrivenRef.current = false
       return
     }
     const el = activeItemRef.current
-    const container = el?.parentElement
+    const container = containerRef.current
     if (!el || !container || direction !== 'vertical') return
-    const top = el.offsetTop
-    const bottom = top + el.offsetHeight
+
+    const activeCenter = el.offsetTop + el.offsetHeight / 2
     const viewTop = container.scrollTop
     const viewBottom = viewTop + container.clientHeight
-    let target: number | null = null
-    if (top < viewTop + FOLLOW_MARGIN) target = top - FOLLOW_MARGIN
-    else if (bottom > viewBottom - FOLLOW_MARGIN)
-      target = bottom - container.clientHeight + FOLLOW_MARGIN
-    if (target === null) return
-    // Mark this scroll as programmatic so it doesn't trip the follow logic.
-    programmaticRef.current = true
-    if (programmaticTimer.current) clearTimeout(programmaticTimer.current)
-    programmaticTimer.current = setTimeout(() => {
-      programmaticRef.current = false
-    }, 400)
-    container.scrollTo({ top: target, behavior: 'smooth' })
+    const needsReveal =
+      !didInitRef.current &&
+      (activeCenter < viewTop + FOLLOW_MARGIN || activeCenter > viewBottom - FOLLOW_MARGIN)
+    didInitRef.current = true
+
+    if (needsReveal) {
+      const max = container.scrollHeight - container.clientHeight
+      const target = Math.max(0, Math.min(max, activeCenter - container.clientHeight / 2))
+      anchorRef.current = activeCenter - target
+      programmaticRef.current = true
+      if (programmaticTimer.current) clearTimeout(programmaticTimer.current)
+      programmaticTimer.current = setTimeout(() => {
+        programmaticRef.current = false
+      }, 400)
+      container.scrollTo({ top: target, behavior: 'auto' })
+    } else {
+      anchorRef.current = activeCenter - viewTop
+    }
   }, [activeId, direction])
 
   useEffect(() => () => {
     if (programmaticTimer.current) clearTimeout(programmaticTimer.current)
   }, [])
 
-  // While the user scrolls the strip, hand the selection to the next/previous
-  // thumbnail once the active one is scrolled past the FOLLOW_MARGIN bound.
+  // While the user scrolls the strip, the active is whichever thumbnail moves
+  // into the active zone (the fixed on-screen spot captured when the selection
+  // was last set by click/keyboard/open). The strip moves and the selection
+  // changes together, and the active stays roughly where the previous one was.
   const handleScroll = useCallback(() => {
     updateFade()
     if (programmaticRef.current || direction !== 'vertical') return
     const el = containerRef.current
-    const active = activeItemRef.current
-    if (!el || !active) return
-    const aTop = active.offsetTop
-    const aBottom = aTop + active.offsetHeight
+    if (!el || anchorRef.current === null) return
+    // The active zone in content space: scroll offset + its on-screen position.
     const viewTop = el.scrollTop
     const viewBottom = viewTop + el.clientHeight
-    const idx = items.findIndex((item) => item.id === activeId)
-    if (idx === -1) return
-    if (aTop < viewTop + FOLLOW_MARGIN && idx < items.length - 1) {
-      // Scrolled down past the active → advance to the next one
+    const zoneY = viewTop + anchorRef.current
+    const thumbs = el.querySelectorAll<HTMLElement>(`.${styles.thumbnailItem}`)
+    if (!thumbs.length) return
+    // Prefer the thumbnail nearest the zone among those fully in view, so the
+    // active never ends up half-clipped at a scroll edge; fall back to the
+    // nearest overall if none is fully visible.
+    let bestIdx = -1
+    let bestDist = Infinity
+    let bestVisibleIdx = -1
+    let bestVisibleDist = Infinity
+    thumbs.forEach((thumb, i) => {
+      const top = thumb.offsetTop
+      const bottom = top + thumb.offsetHeight
+      const dist = Math.abs((top + bottom) / 2 - zoneY)
+      if (dist < bestDist) {
+        bestDist = dist
+        bestIdx = i
+      }
+      const fullyVisible = top >= viewTop - 0.5 && bottom <= viewBottom + 0.5
+      if (fullyVisible && dist < bestVisibleDist) {
+        bestVisibleDist = dist
+        bestVisibleIdx = i
+      }
+    })
+    const chosen = bestVisibleIdx >= 0 ? bestVisibleIdx : bestIdx
+    if (chosen >= 0 && items[chosen] && items[chosen].id !== activeId) {
       scrollDrivenRef.current = true
-      onItemClick(items[idx + 1], idx + 1)
-    } else if (aBottom > viewBottom - FOLLOW_MARGIN && idx > 0) {
-      // Scrolled up past the active → go back to the previous one
-      scrollDrivenRef.current = true
-      onItemClick(items[idx - 1], idx - 1)
+      onItemClick(items[chosen], chosen)
     }
   }, [updateFade, direction, items, activeId, onItemClick])
 
@@ -195,6 +231,11 @@ export const ThumbnailList = ({
       }
       if (idx !== idx0) {
         scrollDrivenRef.current = true
+        // Move the active zone onto the newly selected thumbnail so reversing
+        // the scroll resumes from here instead of snapping back to the old zone.
+        const thumbs = el.querySelectorAll<HTMLElement>(`.${styles.thumbnailItem}`)
+        const thumb = thumbs[idx]
+        if (thumb) anchorRef.current = thumb.offsetTop + thumb.offsetHeight / 2 - el.scrollTop
         onItemClick(items[idx], idx)
       }
     }

--- a/app/src/components/gallery/ThumbnailList/ThumbnailList.tsx
+++ b/app/src/components/gallery/ThumbnailList/ThumbnailList.tsx
@@ -87,8 +87,6 @@ export const ThumbnailList = ({
   // thumbnail moves into this fixed on-screen spot, so the active stays roughly
   // where the previous one was.
   const anchorRef = useRef<number | null>(null)
-  // Whether the initial active item has been revealed/anchored once on open.
-  const didInitRef = useRef(false)
 
   const updateFade = useCallback(() => {
     const el = containerRef.current
@@ -101,44 +99,49 @@ export const ThumbnailList = ({
     setFade((prev) => (prev.top === top && prev.bottom === bottom ? prev : { top, bottom }))
   }, [])
 
-  // Capture the active zone when the selection is set by click / keyboard / open
-  // (not by scrolling): remember where the active thumbnail sits on screen so
-  // later scrolling hands the selection to whatever enters that spot. On the
-  // first open only, if the active item is off screen, reveal it first (and
-  // anchor at its revealed position); a user click already sits where it is, so
-  // the strip is left in place and the zone is taken from its current position.
-  useEffect(() => {
-    if (scrollDrivenRef.current) {
-      // Scroll-driven change: keep the existing zone fixed on screen.
-      scrollDrivenRef.current = false
-      return
-    }
-    const el = activeItemRef.current
-    const container = containerRef.current
-    if (!el || !container || direction !== 'vertical') return
-
-    const activeCenter = el.offsetTop + el.offsetHeight / 2
-    const viewTop = container.scrollTop
-    const viewBottom = viewTop + container.clientHeight
-    const needsReveal =
-      !didInitRef.current &&
-      (activeCenter < viewTop + FOLLOW_MARGIN || activeCenter > viewBottom - FOLLOW_MARGIN)
-    didInitRef.current = true
-
-    if (needsReveal) {
+  // Bring the active thumbnail into comfortable view (clear of the edge fades)
+  // if it's clipped or under an edge, then capture the active zone at its
+  // resulting on-screen position. A comfortably-visible item is left in place,
+  // so its current spot becomes the zone. Used on click/keyboard/open and on
+  // resize, so the active is never left half outside the strip.
+  const anchorActive = useCallback(
+    (animate: boolean) => {
+      const el = activeItemRef.current
+      const container = containerRef.current
+      if (!el || !container || direction !== 'vertical') return
+      const top = el.offsetTop
+      const bottom = top + el.offsetHeight
+      const viewTop = container.scrollTop
+      const viewBottom = viewTop + container.clientHeight
+      let target = viewTop
+      if (top < viewTop + FOLLOW_MARGIN) target = top - FOLLOW_MARGIN
+      else if (bottom > viewBottom - FOLLOW_MARGIN)
+        target = bottom - container.clientHeight + FOLLOW_MARGIN
       const max = container.scrollHeight - container.clientHeight
-      const target = Math.max(0, Math.min(max, activeCenter - container.clientHeight / 2))
-      anchorRef.current = activeCenter - target
+      target = Math.max(0, Math.min(max, target))
+      // Zone = the active's center relative to its (post-scroll) viewport top.
+      anchorRef.current = top + el.offsetHeight / 2 - target
+      if (Math.abs(target - viewTop) < 1) return
+      // Mark this scroll as programmatic so it doesn't trip the follow logic.
       programmaticRef.current = true
       if (programmaticTimer.current) clearTimeout(programmaticTimer.current)
       programmaticTimer.current = setTimeout(() => {
         programmaticRef.current = false
       }, 400)
-      container.scrollTo({ top: target, behavior: 'auto' })
-    } else {
-      anchorRef.current = activeCenter - viewTop
+      container.scrollTo({ top: target, behavior: animate ? 'smooth' : 'auto' })
+    },
+    [direction],
+  )
+
+  // On a click/keyboard/open selection change, reveal + anchor the active.
+  // Skipped when the change came from scrolling (the zone stays fixed there).
+  useEffect(() => {
+    if (scrollDrivenRef.current) {
+      scrollDrivenRef.current = false
+      return
     }
-  }, [activeId, direction])
+    anchorActive(true)
+  }, [activeId, anchorActive])
 
   useEffect(() => () => {
     if (programmaticTimer.current) clearTimeout(programmaticTimer.current)
@@ -243,15 +246,19 @@ export const ThumbnailList = ({
     return () => el.removeEventListener('wheel', onWheel)
   }, [direction, items, activeId, onItemClick])
 
-  // Recompute the fades when the items or the container size change.
+  // Recompute the fades when the items or the container size change, and on
+  // resize keep the active thumbnail in view and refresh the active zone.
   useEffect(() => {
     updateFade()
     const el = containerRef.current
     if (!el) return
-    const ro = new ResizeObserver(updateFade)
+    const ro = new ResizeObserver(() => {
+      updateFade()
+      anchorActive(false)
+    })
     ro.observe(el)
     return () => ro.disconnect()
-  }, [items, updateFade])
+  }, [items, updateFade, anchorActive])
 
   // Feed the scroll-scaled fade heights to the mask (vertical only).
   const fadeStyle = useMemo(() => {

--- a/app/src/components/picker/UploadPrompt/UploadPrompt.module.scss
+++ b/app/src/components/picker/UploadPrompt/UploadPrompt.module.scss
@@ -26,7 +26,12 @@
 .image {
   flex: 1 1 auto;
   min-height: 0;
-  width: 100%;
+  // Full-bleed across the card: cancel the card's 24px horizontal padding so
+  // the artwork box reaches the neutral card edges and stays as large as
+  // possible (the title/buttons keep the 24px inset).
+  width: calc(100% + 48px);
+  margin-left: -24px;
+  margin-right: -24px;
   object-fit: contain;
   margin-top: 8px;
   margin-bottom: 16px;

--- a/app/src/pages/1-Onboarding/Onboarding.module.scss
+++ b/app/src/pages/1-Onboarding/Onboarding.module.scss
@@ -72,6 +72,17 @@
   }
 }
 
+// Safari paints a ~1px black edge along a playing <video> (a WebKit video-layer
+// seam — absent in Chrome, and not present in the media itself). Overscan the
+// video a hair and clip 1px inside the box, so that boundary seam is dropped
+// with no transparent gap (the overscan keeps the box covered) and only ~1px of
+// imperceptible crop. Doubled class beats .image / .image_mobile.
+.video.video {
+  transform: scale(1.01);
+  clip-path: inset(1px);
+}
+
+
 .title {
   margin: 0;
   padding: 4px 24px;

--- a/app/src/pages/1-Onboarding/OnboardingSlides.tsx
+++ b/app/src/pages/1-Onboarding/OnboardingSlides.tsx
@@ -12,6 +12,7 @@ import {
 import { pageIdForSlide } from '@/hooks/onboarding/useOnboardingSlides'
 import type { OnboardingSlideId } from '@/utils/onboarding/onboardingFlow'
 import type { AiutaMode } from '@lib/config'
+import { OnboardingVideo } from './OnboardingVideo'
 import styles from './Onboarding.module.scss'
 
 interface OnboardingSlidesProps {
@@ -113,20 +114,12 @@ export const OnboardingSlides = ({
               {content ? (
                 <>
                   {content.video ? (
-                    <video
-                      className={`${styles.image} ${isMobile ? styles.image_mobile : ''}`}
+                    <OnboardingVideo
+                      className={`${styles.image} ${isMobile ? styles.image_mobile : ''} ${styles.video}`}
+                      src={content.video}
                       poster={content.image}
-                      autoPlay
-                      loop
-                      muted
-                      playsInline
-                      preload="auto"
-                      disablePictureInPicture
-                      tabIndex={-1}
-                      aria-label={content.title}
-                    >
-                      <source src={content.video} type="video/mp4" />
-                    </video>
+                      title={content.title}
+                    />
                   ) : (
                     <img
                       alt={content.title}

--- a/app/src/pages/1-Onboarding/OnboardingVideo.tsx
+++ b/app/src/pages/1-Onboarding/OnboardingVideo.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+interface OnboardingVideoProps {
+  src: string
+  // Shown until the video plays, and used as the static fallback when autoplay
+  // is blocked or the video can't load.
+  poster: string
+  className: string
+  title: string
+}
+
+/**
+ * Looped, muted onboarding video with a robust autoplay path.
+ *
+ * Why this isn't just a `<video autoPlay muted playsInline>`:
+ * - React doesn't reliably set the `muted` *property* from the JSX attribute
+ *   (only the attribute), and WebKit/mobile only allow inline autoplay for a
+ *   genuinely muted video — so we force `muted` on the DOM node.
+ * - The `autoPlay` attribute is ignored by WebKit inside a cross-origin iframe,
+ *   so we call `play()` imperatively (and retry once the media can play).
+ * - If autoplay is still refused (e.g. iOS Low Power Mode) or the media fails,
+ *   we fall back to the poster image instead of leaving a broken native play
+ *   button that blanks the video when tapped.
+ */
+export const OnboardingVideo = ({ src, poster, className, title }: OnboardingVideoProps) => {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) return
+    video.muted = true
+    video.defaultMuted = true
+
+    const tryPlay = () => {
+      const promise = video.play()
+      if (promise && typeof promise.catch === 'function') {
+        promise.catch((error: DOMException) => {
+          // Autoplay was actively blocked → show the static poster instead of a
+          // native play button. Other (transient) errors retry on `canplay`.
+          if (error?.name === 'NotAllowedError') setFailed(true)
+        })
+      }
+    }
+
+    const onError = () => setFailed(true)
+
+    tryPlay()
+    video.addEventListener('canplay', tryPlay)
+    video.addEventListener('error', onError)
+    return () => {
+      video.removeEventListener('canplay', tryPlay)
+      video.removeEventListener('error', onError)
+    }
+  }, [src])
+
+  if (failed) {
+    return <img alt={title} className={className} src={poster} draggable={false} />
+  }
+
+  return (
+    <video
+      ref={videoRef}
+      className={className}
+      poster={poster}
+      autoPlay
+      loop
+      muted
+      playsInline
+      preload="auto"
+      disablePictureInPicture
+      tabIndex={-1}
+      aria-label={title}
+    >
+      <source src={src} type="video/mp4" />
+    </video>
+  )
+}

--- a/app/src/styles/colors.css
+++ b/app/src/styles/colors.css
@@ -15,7 +15,7 @@
 
   /* Background Colors */
   --aiuta-color-background: #ffffff;
-  --aiuta-color-neutral: #f2f2f7;
+  --aiuta-color-neutral: #f6f6f6;
   --aiuta-color-border: #e5e5ea;
 
   /* Selection */


### PR DESCRIPTION
Second design-review pass (follow-ups after #110).

## Changes
- **Image-picker zero-state** — make the artwork full-bleed across the empty-state card (cancel its 24px horizontal padding) so the contained image stays as large as the card allows; designer flagged it as too small. Lighten `--aiuta-color-neutral` (#f2f2f7 → #f6f6f6).
- **Fullscreen thumbnail strip (desktop)** — zone-based selection: keep the active thumbnail's on-screen spot as an "active zone"; scrolling hands the selection to whatever moves into it, so the strip and the active image move together and the active stays roughly in place (no jump to center). Capture the zone on click/keyboard/open and when virtual-scrolling past an edge; reveal a partially-clipped active into view and re-anchor on resize; prefer fully-visible thumbnails so the active is never half-clipped.
- **Onboarding video** — autoplay reliably across browsers: force the muted DOM property + imperative `play()` (the `autoPlay` attribute is ignored by WebKit in a cross-origin iframe), fall back to the poster when autoplay is blocked (iOS Low Power Mode) or the media fails, and drop the 1px black edge Safari paints along the playing video.

## Verification
- `npm run lint` clean (eslint + tsc)
- `npm run build:app` succeeds
- Onboarding video: verified playing in Chrome and Safari desktop; autoplay/no-frame behavior to confirm on target mobile devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)