### PR TITLE
Fullscreen gallery: pinned action buttons + vertical paged scroller

### DIFF
--- a/app/src/components/gallery/FullScreenGallery/FullScreenGallery.module.scss
+++ b/app/src/components/gallery/FullScreenGallery/FullScreenGallery.module.scss
@@ -133,12 +133,13 @@ $actions-reserve: 76px;
     pointer-events: none;
   }
 
-  // Positioned from JS (anchored to the image's right edge); these are the
-  // pre-measure defaults
+  // Fixed bottom-right of the modal, not tied to the image position. 12px from
+  // the right edge (the 52px column sits inside the $actions-reserve strip, 12px
+  // clear of the image area) and 16px from the bottom (matching the image inset).
   .actionButtons {
     position: absolute;
-    right: -64px;
-    bottom: 24px;
+    right: 12px;
+    bottom: 16px;
     display: flex;
     align-items: flex-end;
     flex-direction: column;

--- a/app/src/components/gallery/FullScreenGallery/FullScreenGallery.module.scss
+++ b/app/src/components/gallery/FullScreenGallery/FullScreenGallery.module.scss
@@ -101,36 +101,38 @@ $actions-reserve: 76px;
     }
   }
 
-  // Image area: between the thumbnails and the reserved right strip
-  .centerContent {
+  // Image area: full height, between the thumbnails and the reserved right
+  // strip. A vertical paged scroller — each image is a full-height cell that
+  // snaps into place; the horizontal insets match the old single-image area.
+  .pager {
     position: absolute;
     left: 112px;
     right: $actions-reserve;
-    top: 16px;
-    bottom: 16px;
+    top: 0;
+    bottom: 0;
+    overflow-y: auto;
+    scroll-snap-type: y mandatory;
+    overscroll-behavior: contain;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
   }
 
-  // With no thumbnail strip, mirror the right reserve so the image area is
-  // centered symmetrically
-  .centerContent_noThumbnails {
+  // With no thumbnail strip, mirror the right reserve so the area is centered
+  .pager_noThumbnails {
     left: $actions-reserve;
   }
 
-  // Fills the image area; ZoomableImage fits/zooms the image within it
-  .zoomArea {
-    position: relative;
-    width: 100%;
+  // One image per page: full viewport height, snaps, with the image inset 16px
+  // top/bottom. ZoomableImage fits/zooms within the remaining box.
+  .pagerCell {
     height: 100%;
-  }
-
-  // Outgoing image held behind the new one during a thumbnail switch
-  .prevImage {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-    pointer-events: none;
+    box-sizing: border-box;
+    padding: 16px 0;
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
   }
 
   // Fixed bottom-right of the modal, not tied to the image position. 12px from

--- a/app/src/components/gallery/FullScreenGallery/FullScreenGallery.tsx
+++ b/app/src/components/gallery/FullScreenGallery/FullScreenGallery.tsx
@@ -8,9 +8,9 @@ import { ThumbnailList, IconButton, Confirmation } from '@/components'
 import { useShare, useLogger } from '@/contexts'
 import { useSelectionStrings, usePreventParentScroll } from '@/hooks'
 import { useGenerationsData, useDeleteGeneratedImages } from '@/hooks/data'
-import { combineClassNames } from '@/utils'
 import { ActionButtonsPanel } from './components/ActionButtonsPanel'
-import { ZoomableImage, type ImageBox } from './components/ZoomableImage'
+import { ZoomableImage } from './components/ZoomableImage'
+import { GalleryPager } from './components/GalleryPager'
 import { icons } from './icons'
 import styles from './FullScreenGallery.module.scss'
 
@@ -21,14 +21,6 @@ export const FullScreenGallery = () => {
   const { openShareModal } = useShare()
   const { deleteConfirmationTitle, deleteConfirmationKeep, deleteConfirmationDelete } =
     useSelectionStrings()
-  // The previous image, held behind the new one while it loads so switching
-  // thumbnails doesn't flash an empty frame
-  const [prevUrl, setPrevUrl] = useState<string | null>(null)
-  // ZoomableImage reports its measured box once the new image is ready → drop
-  // the held previous one (the box itself is no longer used for positioning).
-  const handleImageBox = useCallback((box: ImageBox | null) => {
-    if (box) setPrevUrl(null)
-  }, [])
   // Delete confirmation dialog visibility
   const [confirmDelete, setConfirmDelete] = useState(false)
 
@@ -44,34 +36,6 @@ export const FullScreenGallery = () => {
   // Scrolling the thumbnail strip still works (it can consume the gesture).
   const modalRef = useRef<HTMLDivElement>(null)
   usePreventParentScroll(isOpen || !!fullScreenImageUrl, isMobile, modalRef)
-
-  const activeUrl = isOpen
-    ? (images.find((image) => image.id === activeId)?.url ?? images[0]?.url)
-    : undefined
-
-  // Detect an image switch DURING render (not in an effect) so the outgoing
-  // image's layer is already in the same commit that mounts the new one —
-  // otherwise there's a blank frame between unmount and the effect firing.
-  const shownUrlRef = useRef<string | undefined>(undefined)
-  if (!isOpen) {
-    shownUrlRef.current = undefined
-  } else if (activeUrl !== shownUrlRef.current) {
-    if (shownUrlRef.current && activeUrl) setPrevUrl(shownUrlRef.current)
-    shownUrlRef.current = activeUrl
-  }
-
-  // Hold the outgoing image for at most 100ms (the new one usually becomes
-  // ready first and clears it via handleImageBox)
-  useEffect(() => {
-    if (!prevUrl) return
-    const t = setTimeout(() => setPrevUrl(null), 100)
-    return () => clearTimeout(t)
-  }, [prevUrl])
-
-  // Reset when the gallery closes
-  useEffect(() => {
-    if (!isOpen) setPrevUrl(null)
-  }, [isOpen])
 
   const { data: generations = [] } = useGenerationsData()
   const { mutate: deleteGenerations } = useDeleteGeneratedImages()
@@ -205,27 +169,14 @@ export const FullScreenGallery = () => {
           className={styles.leftContent}
         />
 
-        {/* Center content with image and action buttons */}
-        <div
-          className={combineClassNames(
-            styles.centerContent,
-            !hasThumbnails && styles.centerContent_noThumbnails,
-          )}
-        >
-          <div className={styles.zoomArea}>
-            {prevUrl && prevUrl !== activeImage.url && (
-              <img src={prevUrl} alt="" aria-hidden="true" className={styles.prevImage} />
-            )}
-            <ZoomableImage
-              key={activeImage.url}
-              src={activeImage.url}
-              alt="Full Screen Image"
-              tapToClose={false}
-              onClose={closeGallery}
-              onImageBox={handleImageBox}
-            />
-          </div>
-        </div>
+        {/* Center: vertical paged scroller over all images */}
+        <GalleryPager
+          images={images}
+          activeId={activeImage.id}
+          onActiveChange={(id) => dispatch(galleryModalSlice.actions.setActiveGalleryImage(id))}
+          hasThumbnails={hasThumbnails}
+          onClose={closeGallery}
+        />
 
         {/* Fixed bottom-right in the reserved strip — not tied to the image */}
         <ActionButtonsPanel

--- a/app/src/components/gallery/FullScreenGallery/FullScreenGallery.tsx
+++ b/app/src/components/gallery/FullScreenGallery/FullScreenGallery.tsx
@@ -14,9 +14,6 @@ import { ZoomableImage, type ImageBox } from './components/ZoomableImage'
 import { icons } from './icons'
 import styles from './FullScreenGallery.module.scss'
 
-// Gap between the image's right edge and the action buttons column
-const ACTIONS_GAP = 12
-
 export const FullScreenGallery = () => {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
@@ -27,11 +24,9 @@ export const FullScreenGallery = () => {
   // The previous image, held behind the new one while it loads so switching
   // thumbnails doesn't flash an empty frame
   const [prevUrl, setPrevUrl] = useState<string | null>(null)
-  // Displayed image rect, so the action buttons can hug its right edge
-  const [imageBox, setImageBox] = useState<ImageBox | null>(null)
+  // ZoomableImage reports its measured box once the new image is ready → drop
+  // the held previous one (the box itself is no longer used for positioning).
   const handleImageBox = useCallback((box: ImageBox | null) => {
-    setImageBox(box)
-    // New image is measured/loaded → drop the held previous one
     if (box) setPrevUrl(null)
   }, [])
   // Delete confirmation dialog visibility
@@ -230,27 +225,15 @@ export const FullScreenGallery = () => {
               onImageBox={handleImageBox}
             />
           </div>
-          <ActionButtonsPanel
-            onShare={() => openShareModal(activeImage.url)}
-            onDownload={() => downloadImage(activeImage.url)}
-            onDelete={() => setConfirmDelete(true)}
-            showDelete={showDelete}
-            // Hug the image's visible right edge (clamped to the image area, so
-            // the column stops at the reserved strip instead of sliding under a
-            // zoomed image). Vertical is anchored to the fitted image's bottom.
-            style={
-              imageBox
-                ? {
-                    left: Math.min(imageBox.right, imageBox.containerW) + ACTIONS_GAP,
-                    top: imageBox.fitBottom,
-                    right: 'auto',
-                    bottom: 'auto',
-                    transform: 'translateY(-100%)',
-                  }
-                : undefined
-            }
-          />
         </div>
+
+        {/* Fixed bottom-right in the reserved strip — not tied to the image */}
+        <ActionButtonsPanel
+          onShare={() => openShareModal(activeImage.url)}
+          onDownload={() => downloadImage(activeImage.url)}
+          onDelete={() => setConfirmDelete(true)}
+          showDelete={showDelete}
+        />
 
         {/* Close button (top-right) */}
         <IconButton

--- a/app/src/components/gallery/FullScreenGallery/components/ActionButtonsPanel.tsx
+++ b/app/src/components/gallery/FullScreenGallery/components/ActionButtonsPanel.tsx
@@ -8,8 +8,6 @@ interface ActionButtonsPanelProps {
   onDownload: () => void
   onDelete?: () => void
   showDelete?: boolean
-  /** Dynamic positioning (anchors the column to the image's right edge) */
-  style?: React.CSSProperties
 }
 
 export const ActionButtonsPanel = ({
@@ -17,10 +15,9 @@ export const ActionButtonsPanel = ({
   onDownload,
   onDelete,
   showDelete,
-  style,
 }: ActionButtonsPanelProps) => {
   return (
-    <div className={styles.actionButtons} style={style}>
+    <div className={styles.actionButtons}>
       <IconButton
         icon={icons.share}
         label="Share"

--- a/app/src/components/gallery/FullScreenGallery/components/GalleryPager.tsx
+++ b/app/src/components/gallery/FullScreenGallery/components/GalleryPager.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback, useEffect, useRef } from 'react'
+import { combineClassNames } from '@/utils'
+import { ZoomableImage } from './ZoomableImage'
+import styles from '../FullScreenGallery.module.scss'
+
+interface GalleryImage {
+  id: string
+  url: string
+}
+
+interface GalleryPagerProps {
+  images: GalleryImage[]
+  activeId: string
+  /** Called when scrolling brings a different cell into view. */
+  onActiveChange: (id: string) => void
+  /** Narrower left inset when the thumbnail strip isn't shown. */
+  hasThumbnails: boolean
+  onClose: () => void
+}
+
+/**
+ * Vertical paged scroller for the desktop fullscreen gallery: every image is a
+ * full-height cell (scroll-snap paging), each holding a zoomable image inset
+ * 16px top/bottom. Scrolling drives the active selection; an external selection
+ * change (thumbnail click / keyboard) jumps the scroll to that cell with no
+ * animation.
+ */
+export const GalleryPager = ({
+  images,
+  activeId,
+  onActiveChange,
+  hasThumbnails,
+  onClose,
+}: GalleryPagerProps) => {
+  const ref = useRef<HTMLDivElement>(null)
+  // A programmatic jump is in flight → don't let its scroll events drive the
+  // selection (avoids a scroll↔select feedback loop).
+  const programmaticRef = useRef(false)
+  const programmaticTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The last selection change came from scrolling → don't jump the scroll back.
+  const scrollDrivenRef = useRef(false)
+
+  // Jump the scroll to the active cell when the selection changes from outside
+  // (thumbnail click / keyboard / open / delete) — instantly, no animation.
+  useEffect(() => {
+    if (scrollDrivenRef.current) {
+      scrollDrivenRef.current = false
+      return
+    }
+    const el = ref.current
+    if (!el) return
+    const idx = images.findIndex((image) => image.id === activeId)
+    if (idx < 0) return
+    const target = idx * el.clientHeight
+    if (Math.abs(el.scrollTop - target) < 1) return
+    programmaticRef.current = true
+    if (programmaticTimer.current) clearTimeout(programmaticTimer.current)
+    programmaticTimer.current = setTimeout(() => {
+      programmaticRef.current = false
+    }, 200)
+    el.scrollTo({ top: target, behavior: 'auto' })
+  }, [activeId, images])
+
+  useEffect(
+    () => () => {
+      if (programmaticTimer.current) clearTimeout(programmaticTimer.current)
+    },
+    [],
+  )
+
+  // While the user scrolls, the cell nearest the viewport becomes active.
+  const handleScroll = useCallback(() => {
+    const el = ref.current
+    if (!el || programmaticRef.current) return
+    const idx = Math.round(el.scrollTop / el.clientHeight)
+    const image = images[idx]
+    if (image && image.id !== activeId) {
+      scrollDrivenRef.current = true
+      onActiveChange(image.id)
+    }
+  }, [images, activeId, onActiveChange])
+
+  return (
+    <div
+      ref={ref}
+      className={combineClassNames(styles.pager, !hasThumbnails && styles.pager_noThumbnails)}
+      onScroll={handleScroll}
+    >
+      {images.map((image) => (
+        <div key={image.id} className={styles.pagerCell}>
+          <ZoomableImage
+            src={image.url}
+            alt="Full Screen Image"
+            tapToClose={false}
+            onClose={onClose}
+            allowPageScroll
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/src/components/gallery/FullScreenGallery/components/ZoomableImage.tsx
+++ b/app/src/components/gallery/FullScreenGallery/components/ZoomableImage.tsx
@@ -43,6 +43,13 @@ interface ZoomableImageProps {
    * the image is measured.
    */
   onImageBox?: (box: ImageBox | null) => void
+  /**
+   * When the image sits in a scroll/pager, let a plain (non-pinch) wheel pass
+   * through to the scroller while the image is at fit scale, so it can page.
+   * Zoom is then reached via pinch (ctrl+wheel) or double-click; once zoomed in,
+   * the wheel pans/zooms the image as usual.
+   */
+  allowPageScroll?: boolean
 }
 
 interface Transform {
@@ -70,6 +77,7 @@ export const ZoomableImage = ({
   onClose,
   tapToClose = true,
   onImageBox,
+  allowPageScroll = false,
 }: ZoomableImageProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const natRef = useRef<{ w: number; h: number } | null>(null)
@@ -349,6 +357,9 @@ export const ZoomableImage = ({
       const m = metrics()
       const nat = natRef.current
       if (!m || !nat) return
+      // In a pager, a plain wheel at fit scale scrolls/pages instead of zooming.
+      const atFit = tfRef.current.s <= fitScale(m.cw, m.ch) * 1.01
+      if (allowPageScroll && !e.ctrlKey && atFit) return
       e.preventDefault()
       setAnimate(false)
 
@@ -466,7 +477,7 @@ export const ZoomableImage = ({
       window.removeEventListener('mousemove', onMouseMove)
       window.removeEventListener('mouseup', onMouseUp)
     }
-  }, [metrics, fitScale, clamp, apply, reset, onClose])
+  }, [metrics, fitScale, clamp, apply, reset, onClose, allowPageScroll])
 
   // Clear any pending single-tap close on unmount.
   useEffect(() => () => cancelPendingClose(), [cancelPendingClose])


### PR DESCRIPTION
Experiments on the desktop fullscreen gallery.

## Changes
- **Action buttons pinned** — the share/download/delete column used to follow the zoomed image's right edge via JS measurement. It's now fixed bottom-right of the modal (right 12px, bottom 16px, inside the reserved right strip), independent of the image position. Drops the `imageBox` state, `ACTIONS_GAP`, and the panel's dynamic `style` prop.
- **Center is a vertical paged scroller** — replace the single swapped `ZoomableImage` with a `GalleryPager`: a full-height vertical scroll-snap pager rendering every image as a page (16px top/bottom inset, same horizontal insets as before). Scrolling drives the active selection; a thumbnail click / keyboard selection jumps the scroll to that cell with no animation. Removes the old single-image swap/crossfade plumbing.
- **Wheel arbitration** — `ZoomableImage` gains an `allowPageScroll` prop: a plain wheel at fit scale passes through to the pager (paging), while zoom stays on pinch (ctrl+wheel) / double-click and panning when zoomed in. The mobile single-image viewer is unchanged.

## Notes
- When an image is zoomed in, the wheel pans/zooms it rather than paging (zoom out to page again).
- All images mount a `ZoomableImage` up front — fine for typical generation counts; could be virtualized later if a gallery grows large.

## Verification
- `npm run lint` clean (eslint + tsc)
- `npm run build:app` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)