### PR TITLE
Fix results being duplicated in the fullscreen gallery

### DIFF
--- a/app/src/hooks/tryOn/useTryOnGeneration.ts
+++ b/app/src/hooks/tryOn/useTryOnGeneration.ts
@@ -56,6 +56,10 @@ export const useTryOnGeneration = () => {
 
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
   const usedImageRef = useRef<InputImage | null>(null)
+  // The operation whose terminal status has already been handled. Clearing the
+  // interval stops future polls but not the ones already in flight, so several
+  // can resolve SUCCESS at once — this guards the handler from running twice.
+  const settledOperationRef = useRef<string | null>(null)
 
   const getAuthParams = useCallback((): ApiAuthParams | null => {
     const auth = rpc.config.auth
@@ -265,16 +269,25 @@ export const useTryOnGeneration = () => {
       try {
         const result = await TryOnApiService.getGenerationResult(operationId, auth)
 
+        // Handle a terminal status only once per operation: in-flight polls that
+        // resolve after the first one must not re-run the handlers (which would
+        // duplicate the result / history entry).
+        const settleOnce = () => {
+          if (settledOperationRef.current === operationId) return false
+          settledOperationRef.current = operationId
+          return true
+        }
+
         switch (result.status) {
           case 'SUCCESS':
-            handleGenerationSuccess(result)
+            if (settleOnce()) handleGenerationSuccess(result)
             break
           case 'FAILED':
           case 'CANCELLED':
-            handleGenerationError(result)
+            if (settleOnce()) handleGenerationError(result)
             break
           case 'ABORTED':
-            handleGenerationAborted(result)
+            if (settleOnce()) handleGenerationAborted(result)
             break
           default:
             // Continue waiting for final status
@@ -403,8 +416,9 @@ export const useTryOnGeneration = () => {
         return
       }
 
-      // Save operation ID to Redux
+      // Save operation ID to Redux; arm the once-only terminal guard for it
       dispatch(tryOnSlice.actions.setOperationId(operationId))
+      settledOperationRef.current = null
 
       // Step 3: After 4 seconds, switch to generating stage
       setTimeout(() => {

--- a/app/src/store/slices/generationsSlice/generationsSlice.ts
+++ b/app/src/store/slices/generationsSlice/generationsSlice.ts
@@ -29,6 +29,10 @@ export const generationsSlice = createSlice({
     },
 
     addCurrentResult: (state, action: PayloadAction<GeneratedImage>) => {
+      // Dedupe by id: a polling race can deliver the same result more than once
+      // (several in-flight status polls all return SUCCESS before the interval
+      // is cleared), which would otherwise show the image multiple times.
+      if (state.currentResults.some((image) => image.id === action.payload.id)) return
       state.currentResults.push(action.payload)
     },
 


### PR DESCRIPTION
Intermittent bug: a single try-on's result could appear 2–3 times in the results fullscreen gallery.

**Cause — polling race.** Generation status is polled every 3s with async requests, so when a generation finishes several in-flight polls can resolve `SUCCESS` at once and run `handleGenerationSuccess` more than once (`clearInterval` only stops future ticks), pushing the same result repeatedly.

**Fix.** Guard terminal handling to run once per operation, and dedupe `addCurrentResult` by id as a safety net.

Cross-session accumulation of results (the fullscreen gallery showing the session's results) is intended and left as-is.

## Verification
- `npm run lint` clean (eslint + tsc)
- `npm run build:app` succeeds
- Timing-dependent, so verify a try-on no longer shows the same result more than once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)