### PR TITLE
Re-enable desktop fullscreen zoom (pinch / double-click)

### DIFF
--- a/app/src/components/gallery/FullScreenGallery/FullScreenGallery.tsx
+++ b/app/src/components/gallery/FullScreenGallery/FullScreenGallery.tsx
@@ -239,7 +239,10 @@ export const FullScreenGallery = () => {
               tapToClose={false}
               onClose={closeGallery}
               onImageBox={handleImageBox}
-              disableZoom
+              // At fit, a plain wheel/trackpad scroll bubbles to the thumbnail
+              // strip (priority); pinch (ctrl+wheel) and double-click zoom, and
+              // once zoomed in the wheel pans/zooms (no longer forwarded).
+              deferWheelAtFit
             />
           </div>
         </div>


### PR DESCRIPTION
Design compromise: bring back zoom in the desktop fullscreen gallery while keeping thumbnail scroll as the default.

Switches the central image from `disableZoom` back to `deferWheelAtFit`:

1. **Not zoomed** → a plain wheel/trackpad scroll bubbles to the thumbnail strip (scroll has priority, both wheel and trackpad).
2. **Pinch** (trackpad) / **Ctrl+wheel** → zoom (same event, so it returns together).
3. **Double-click** on the image → toggle zoom.
4. **Zoomed in** → the wheel pans/zooms and is no longer forwarded; zoom out (double-click) to scroll the strip again.

The `deferWheelAtFit` mechanism already existed in `ZoomableImage`, so this is a one-line switch. `disableZoom` stays as an available prop (no longer used by the gallery).

## Verification
- `npm run lint` clean (eslint + tsc)
- `npm run build:app` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)