### PR TITLE
Unify results and generations into a single history

### DIFF
--- a/app/src/components/debug/ClearStorageBridge.tsx
+++ b/app/src/components/debug/ClearStorageBridge.tsx
@@ -54,7 +54,7 @@ export const ClearStorageBridge = () => {
       dispatch(uploadsSlice.actions.setIsSelecting(false))
       dispatch(generationsSlice.actions.clearSelectedImages())
       dispatch(generationsSlice.actions.setIsSelecting(false))
-      dispatch(generationsSlice.actions.clearCurrentResults())
+      dispatch(generationsSlice.actions.clearCurrentResultId())
 
       // Back to the entry point so the initial route is re-decided cleanly
       navigate('/', { replace: true })

--- a/app/src/hooks/data/useGenerationsData.ts
+++ b/app/src/hooks/data/useGenerationsData.ts
@@ -30,8 +30,23 @@ export function useAddGeneration() {
 
   return useMutation({
     mutationFn: (image: GeneratedImage) => backend.addGeneratedImage(image),
+    // Optimistically prepend (newest-first, same as storage) so the just-
+    // generated image is in the cache instantly — the results screen reads it
+    // from here, with no wait for the IndexedDB write. Kept synchronous (no
+    // await) so the cache is updated before the navigation to /results renders.
+    onMutate: (image) => {
+      const previous = queryClient.getQueryData<GeneratedImage[]>(generationsKeys.all) ?? []
+      queryClient.setQueryData(generationsKeys.all, [
+        image,
+        ...previous.filter((item) => item.id !== image.id),
+      ])
+      return { previous }
+    },
+    onError: (_error, _image, context) => {
+      if (context?.previous) queryClient.setQueryData(generationsKeys.all, context.previous)
+    },
     onSuccess: (updatedImages) => {
-      // Update cache with new list
+      // Replace with the authoritative list from storage
       queryClient.setQueryData(generationsKeys.all, updatedImages)
     },
   })

--- a/app/src/hooks/results/useResultsGallery.ts
+++ b/app/src/hooks/results/useResultsGallery.ts
@@ -1,23 +1,28 @@
 import { useMemo } from 'react'
 import { useAppSelector } from '@/store/store'
-import { currentResultsSelector } from '@/store/slices/generationsSlice/selectors'
+import { currentResultIdSelector } from '@/store/slices/generationsSlice/selectors'
+import { useGenerationsData } from '@/hooks/data'
 
 /**
- * Hook for managing results gallery
- * Uses only Redux currentResults for instant display
- * (storage is used only for history page /generations)
+ * Results gallery — the results screen shows the latest generation from the
+ * single (persisted) generations history, identified by currentResultId; the
+ * fullscreen opens that same history at that image. There is no separate
+ * "current results" list anymore, so deleting the image anywhere is reflected
+ * here immediately.
  */
 export const useResultsGallery = () => {
-  // Fresh results from Redux (instant, no storage delay), stored oldest → newest
-  const generatedImages = useAppSelector(currentResultsSelector)
+  const currentResultId = useAppSelector(currentResultIdSelector)
+  // History is stored newest-first
+  const { data: images = [] } = useGenerationsData()
 
-  // Expose newest → oldest, to match the generations history ordering (newest at
-  // the top of the fullscreen thumbnail strip / first in the swipe sequence).
-  const images = useMemo(() => [...generatedImages].reverse(), [generatedImages])
+  const currentImage = useMemo(
+    () => images.find((image) => image.id === currentResultId),
+    [images, currentResultId],
+  )
 
   return {
-    // Most recent result (now the first item)
-    currentImage: images[0],
+    currentImage,
+    // Full history (newest-first), for the fullscreen gallery
     images,
   }
 }

--- a/app/src/hooks/tryOn/useTryOnGeneration.ts
+++ b/app/src/hooks/tryOn/useTryOnGeneration.ts
@@ -151,19 +151,22 @@ export const useTryOnGeneration = () => {
 
         dispatch(tryOnSlice.actions.setGeneratedImageUrl(generatedImage.url))
 
-        // Immediately store result in Redux for instant display on /results
-        dispatch(generationsSlice.actions.addCurrentResult(generatedImage))
+        // Mark this as the current result shown on /results (the image itself
+        // lives in the single generations history below).
+        dispatch(generationsSlice.actions.setCurrentResultId(generatedImage.id))
 
         // Common logic after navigation
         const finalizeGeneration = () => {
+          // Persist to the generations history first — its optimistic update
+          // puts the image in the cache synchronously, so /results can read it
+          // instantly (this replaces the old separate currentResults array).
+          addGeneration(generatedImage)
+
           // Replace: a result is the end of a generation cycle and has no back
           // button, so it consumes the /tryon (loading) entry instead of
           // stacking — together with the picker→/tryon replaces this keeps the
           // history from growing on every generation.
           navigate('/results', { replace: true })
-
-          // After navigation, add images to history (background, slow storage)
-          addGeneration(generatedImage)
 
           const imageToStore = usedImageRef.current
           if (imageToStore) {

--- a/app/src/pages/5-Results/ResultsDesktop.tsx
+++ b/app/src/pages/5-Results/ResultsDesktop.tsx
@@ -17,11 +17,13 @@ export default function ResultsDesktop() {
 
   const openFullScreen = () => {
     if (!currentImage) return
+    // The results fullscreen IS the generations history, opened at the current
+    // result — so delete is available (modalType 'generations').
     dispatch(
       galleryModalSlice.actions.openGalleryModal({
         images: images.map(({ id, url }) => ({ id, url })),
         activeId: currentImage.id,
-        modalType: 'results',
+        modalType: 'generations',
       }),
     )
   }

--- a/app/src/pages/5-Results/ResultsMobile.tsx
+++ b/app/src/pages/5-Results/ResultsMobile.tsx
@@ -80,15 +80,15 @@ export default function ResultsMobile() {
     navigate('/models')
   }, [navigate])
 
-  // Open the fullscreen viewer with the full session results, so it can be
-  // swiped through (same data/flow as desktop; mobile renders a single image).
+  // Open the fullscreen viewer on the generations history at the current
+  // result, so it can be swiped through (same data/flow as desktop).
   const openFullScreen = useCallback(() => {
     if (!currentImage) return
     dispatch(
       galleryModalSlice.actions.openGalleryModal({
         images: images.map(({ id, url }) => ({ id, url })),
         activeId: currentImage.id,
-        modalType: 'results',
+        modalType: 'generations',
       }),
     )
   }, [currentImage, images, dispatch])

--- a/app/src/pages/5-Results/index.tsx
+++ b/app/src/pages/5-Results/index.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useAppSelector, useAppDispatch } from '@/store/store'
 import { isMobileSelector } from '@/store/slices/appSlice'
 import { productIdsSelector, tryOnSlice } from '@/store/slices/tryOnSlice'
+import { currentResultIdSelector } from '@/store/slices/generationsSlice/selectors'
+import { useGenerationsData } from '@/hooks/data'
 import { useRpc } from '@/contexts'
 import ResultsDesktop from './ResultsDesktop'
 import ResultsMobile from './ResultsMobile'
@@ -18,9 +21,21 @@ import ResultsMobile from './ResultsMobile'
  */
 export default function ResultsPage() {
   const rpc = useRpc()
+  const navigate = useNavigate()
   const dispatch = useAppDispatch()
   const isMobile = useAppSelector(isMobileSelector)
   const productIds = useAppSelector(productIdsSelector)
+  const currentResultId = useAppSelector(currentResultIdSelector)
+  const { data: generations = [], isLoading } = useGenerationsData()
+
+  // The results screen is tied to a specific generation. If it's gone (deleted
+  // here, in the fullscreen, or on the history screen), there's nothing to show
+  // → fall back to the input step, as if the widget was just opened.
+  useEffect(() => {
+    if (isLoading) return
+    const hasResult = !!currentResultId && generations.some((g) => g.id === currentResultId)
+    if (!hasResult) navigate('/', { replace: true })
+  }, [isLoading, currentResultId, generations, navigate])
 
   // Clear the generating flag here rather than at generation success: doing it
   // there re-rendered the still-mounted try-on page into its picker state for a

--- a/app/src/store/slices/generationsSlice/generationsSlice.ts
+++ b/app/src/store/slices/generationsSlice/generationsSlice.ts
@@ -1,20 +1,22 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
-import type { GeneratedImage } from '@lib/models'
 
 /**
  * Generations UI State
- * - currentResults: Fresh generated images (not yet persisted to storage)
+ * - currentResultId: id of the just-generated image shown on /results. The
+ *   image itself lives in the single persisted generations history; this is
+ *   only a pointer, so deleting it anywhere makes /results fall back to the
+ *   input step.
  * - selectedImages: Images selected for deletion in gallery
  * - isSelecting: Selection mode in gallery
  */
 export interface GenerationsState {
-  currentResults: GeneratedImage[]
+  currentResultId: string | null
   selectedImages: Array<string>
   isSelecting: boolean
 }
 
 const initialState: GenerationsState = {
-  currentResults: [],
+  currentResultId: null,
   selectedImages: [],
   isSelecting: false,
 }
@@ -23,21 +25,13 @@ export const generationsSlice = createSlice({
   name: 'generations',
   initialState,
   reducers: {
-    // Fresh generation results (immediate, no storage delay)
-    setCurrentResults: (state, action: PayloadAction<GeneratedImage[]>) => {
-      state.currentResults = action.payload
+    // The image to show on the results screen (the latest generation)
+    setCurrentResultId: (state, action: PayloadAction<string>) => {
+      state.currentResultId = action.payload
     },
 
-    addCurrentResult: (state, action: PayloadAction<GeneratedImage>) => {
-      // Dedupe by id: a polling race can deliver the same result more than once
-      // (several in-flight status polls all return SUCCESS before the interval
-      // is cleared), which would otherwise show the image multiple times.
-      if (state.currentResults.some((image) => image.id === action.payload.id)) return
-      state.currentResults.push(action.payload)
-    },
-
-    clearCurrentResults: (state) => {
-      state.currentResults = []
+    clearCurrentResultId: (state) => {
+      state.currentResultId = null
     },
 
     // Selection state for gallery

--- a/app/src/store/slices/generationsSlice/selectors.ts
+++ b/app/src/store/slices/generationsSlice/selectors.ts
@@ -1,5 +1,5 @@
 import { RootState } from '@/store/store'
 
-export const currentResultsSelector = (state: RootState) => state.generations.currentResults
+export const currentResultIdSelector = (state: RootState) => state.generations.currentResultId
 export const selectedImagesSelector = (state: RootState) => state.generations.selectedImages
 export const generationsIsSelectingSelector = (state: RootState) => state.generations.isSelecting


### PR DESCRIPTION
Collapse the two "histories" (the in-memory `currentResults` and the persisted generations history) into a single source of truth, so the current result can be deleted immediately and never goes stale.

## Why
`currentResults` was a Redux duplicate of the persisted generations (same ids), kept only to show the just-generated image without waiting for the IndexedDB write. It caused: no way to delete the current result, and "delete in history → still shown on results" confusion.

## Changes
- `useAddGeneration` optimistically prepends to the React Query cache (synchronous) — the new generation appears instantly, which was the only reason `currentResults` existed.
- `generationsSlice`: `currentResults[]` → `currentResultId` pointer.
- `useResultsGallery` reads the current image from the generations history by id; the results fullscreen opens that same history at the current result.
- Results fullscreen uses `modalType: 'generations'` → the desktop viewer has a delete button; deleting keeps the gallery open while images remain, closes on the last.
- `/results` guards on `currentResultId`: if the image is gone (deleted in the fullscreen or on the history screen), it falls back to the input step (picker / QR) as if freshly opened.

## Verification
- `npm run lint` clean (eslint + tsc)
- `npm run build:app` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)