### PR TITLE
Demo: disable the single-item filter via ?filter=0

### DIFF
--- a/demo/src/utils/settings.ts
+++ b/demo/src/utils/settings.ts
@@ -9,11 +9,19 @@ const FILTER_KEY = 'aiuta-demo-filter-single-item-try-on'
 type Listener = () => void
 const listeners = new Set<Listener>()
 
+// A `filter` query param (0/1) takes precedence over the stored preference —
+// the admin panel's test link opens with `filter=0` to show the full catalog.
+const filterParam = new URLSearchParams(window.location.search).get('filter')
+
 let filterEnabled = false
-try {
-  filterEnabled = localStorage.getItem(FILTER_KEY) === '1'
-} catch {
-  // Storage can be unavailable (private mode etc.) — default to off
+if (filterParam === '0' || filterParam === '1') {
+  filterEnabled = filterParam === '1'
+} else {
+  try {
+    filterEnabled = localStorage.getItem(FILTER_KEY) === '1'
+  } catch {
+    // Storage can be unavailable (private mode etc.) — default to off
+  }
 }
 
 export const isTryOnFilterEnabled = (): boolean => filterEnabled


### PR DESCRIPTION
## What

The demo's **Filter single items** toggle is persisted in localStorage and defaults off. This lets a `filter` query param override that stored preference:

- `filter=0` → filter **off** (show the full catalog)
- `filter=1` → filter **on**
- absent → unchanged (localStorage, default off)

This is the param the admin panel puts in a demo's **test link** (`demo.html?code=<key>&filter=0`), so opening that link always previews the full catalog regardless of any locally-saved toggle. The gear-menu toggle stays functional (the param only seeds the initial state).

## Verify
- `npm run lint` (eslint + tsc) and `npm run build:demo:debug` — green.
- Open the demo with `?filter=0` → single-item filter is off; with `?filter=1` → on; without the param → the saved preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)