### PR TITLE
Demo: read catalog attributes from SkuItem.metadata, extra as fallback

### DIFF
--- a/demo/src/models/product.ts
+++ b/demo/src/models/product.ts
@@ -2,7 +2,10 @@
 
 export type SkuCapabilityReadinessStatus = 'absent' | 'preparing' | 'ready' | 'rejected' | 'failed'
 
-/** Merchant-defined free-form fields the demo understands */
+/** Merchant-defined free-form fields the demo understands. Live in the
+ *  top-level `metadata` (the current home) and, for items created before
+ *  the move, in the legacy `product_info.extra` — resolved per field,
+ *  metadata first. */
 export interface SkuItemExtra {
   /** Catalog sort key: the smaller, the earlier in the list */
   order?: number | null
@@ -28,6 +31,7 @@ export interface UnifiedSkuItem {
     store_url?: string | null
     extra?: SkuItemExtra | null
   }
+  metadata?: SkuItemExtra | null
   capabilities: {
     try_on?: boolean
     outfit_recommendations?: boolean

--- a/demo/src/utils/api.ts
+++ b/demo/src/utils/api.ts
@@ -51,19 +51,26 @@ export const fetchSkuPage = async (offset: number): Promise<SkuPage> => {
     )
     .map((item) => {
       const extra = item.product_info?.extra ?? {}
+      const metadata = item.metadata ?? {}
+      // Resolved PER FIELD: `metadata` (the current home of these attributes)
+      // wins whenever it carries the key at all — even false/0 — and only a
+      // missing key falls back to the legacy `product_info.extra`.
+      const titleImage = metadata.title_image ?? extra.title_image
+      const sourceImages = metadata.source_images ?? extra.source_images
+      const order = metadata.order ?? extra.order
+      const singleItemTryOn = metadata.single_item_try_on ?? extra.single_item_try_on
       return {
         sku_id: item.sku_id,
         title: item.product_info?.title ?? item.sku_id,
         brand: item.product_info?.brand ?? undefined,
         gender: item.product_info?.gender ?? undefined,
-        // Image priority: extra.title_image | source_images[0] | image_urls[0]
-        image_url:
-          extra.title_image || extra.source_images?.[0] || item.product_info?.image_urls?.[0] || '',
+        // Image priority: title_image | source_images[0] | image_urls[0]
+        image_url: titleImage || sourceImages?.[0] || item.product_info?.image_urls?.[0] || '',
         mode: isShoeCategory(item.product_info?.category)
           ? ('shoes' as const)
           : ('general' as const),
-        order: typeof extra.order === 'number' ? extra.order : Number.MAX_SAFE_INTEGER,
-        singleItemTryOn: extra.single_item_try_on === true,
+        order: typeof order === 'number' ? order : Number.MAX_SAFE_INTEGER,
+        singleItemTryOn: singleItemTryOn === true,
       }
     })
 


### PR DESCRIPTION
## What

`order` / `single_item_try_on` / `title_image` / `source_images` moved to the top-level `SkuItem.metadata`. The demo catalog resolves each field **per field**: a key present in `metadata` (even `false`/`0`) wins — `??`, not `||`, so `metadata.single_item_try_on: false` beats a legacy `extra: true` — and only a missing key falls back to the legacy `product_info.extra` (old demos come back as `metadata: {}`). The image chain stays `title_image → source_images[0] → image_urls[0]`.

## Testing

- `npm run lint` (eslint + tsc) passes; touched files prettier-clean.
- Traced against a real prod item with `metadata: {}` + populated `extra` (listed, ordered, extra title image) and the false-in-metadata / true-in-extra conflict (metadata wins, item hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)